### PR TITLE
Fail the Step Function execution if Elasticsearch cluster status is not green

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -117,6 +117,25 @@ Resources:
         Variables:
           ASG_NAME: !Sub ${AutoScalingGroupName}
 
+  AddElasticsearchNodeLambda:
+    Type: "AWS::Lambda::Function"
+    DependsOn: NodeRotationLambdaRole
+    Properties:
+      FunctionName:
+          !Sub enr-add-elasticsearch-node
+      Description: "Adds a new node to the Elasticsearch cluster"
+      Handler: "addElasticsearchNode.handler"
+      Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
+      Code:
+        S3Bucket: !Sub ${S3Bucket}
+        S3Key: !Sub ${S3Key}
+      MemorySize: 512
+      Runtime: nodejs8.10
+      Timeout: 300
+      Environment:
+        Variables:
+          ASG_NAME: !Sub ${AutoScalingGroupName}
+
   NodeRotationStepFunction:
     Type: "AWS::StepFunctions::StateMachine"
     DependsOn: ElasticsearchClusterStatusCheckLambda
@@ -142,15 +161,28 @@ Resources:
                  "Type": "Choice",
                  "Choices": [
                    {
-                     "Variable": "$",
-                     "StringEquals": "green"
+                     "Not": {
+                       "Variable": "$.clusterStatus",
+                       "StringEquals": "green"
+                     },
+                     "Next": "FailState"
                    }
                  ],
-                 "end": true
+                 "Default": "AddNewElasticsearchNode"
+               },
+               "FailState": {
+                 "Type": "Fail",
+                 "Cause": "Unhealthy Cluster!"
+               },
+               "AddNewElasticsearchNode": {
+                 "Type": "Task",
+                 "Resource": "${AddElasticsearchNodeArn}",
+                 "End": true
                }
              }
            }
           -
             GetOldestInstanceArn: !GetAtt GetOldestInstanceLambda.Arn
             StatuscheckArn: !GetAtt ElasticsearchClusterStatusCheckLambda.Arn
+            AddElasticsearchNodeArn: !GetAtt AddElasticsearchNodeLambda.Arn
       RoleArn: !GetAtt StatesExecutionRole.Arn

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -136,7 +136,17 @@ Resources:
                "CheckClusterStatus": {
                  "Type": "Task",
                  "Resource": "${StatuscheckArn}",
-                 "End": true
+                 "Next": "StatusIsGreen"
+               },
+               "StatusIsGreen": {
+                 "Type": "Choice",
+                 "Choices": [
+                   {
+                     "Variable": "$",
+                     "StringEquals": "green"
+                   }
+                 ],
+                 "end": true
                }
              }
            }

--- a/src/addElasticsearchNode.ts
+++ b/src/addElasticsearchNode.ts
@@ -1,0 +1,6 @@
+export async function handler(event) {
+    return new Promise((resolve, reject) => {
+        resolve("done");
+    })
+
+}

--- a/src/clusterStatusCheck.ts
+++ b/src/clusterStatusCheck.ts
@@ -1,10 +1,10 @@
 import {ssmCommand} from './utils/ssmCommand';
 import {StandardOutputContent} from 'aws-sdk/clients/ssm';
 
-export async function handler(instanceId: string): Promise<string> {
+export async function handler(instanceId: string): Promise<Object> {
     return ssmCommand('curl localhost:9200/_cluster/health', instanceId)
         .then((result: StandardOutputContent) => {
             const json = JSON.parse(result);
-            return json.status;
+            return { "instanceId": instanceId, "clusterStatus": json.status } ;
         })
 }


### PR DESCRIPTION
If the cluster status is not green, we should fail the execution rather than attempting to rotate a node:
https://trello.com/c/Nx41M135/107-add-step-function-logic-which-fails-the-execution-if-es-cluster-status-is-not-green

* Implement the above logic, using a choice state: https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-choice-state.html
* Add a FailState which will end the execution if the status is not green: https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-fail-state.html
* Add a new placeholder lambda so that we can continue the execution if the cluster is healthy

We should add an alert based on the Failed Executions CloudWatch metric, but I'll do that in a separate PR (it's tracked here: https://trello.com/c/IBFsJWIo/111-add-alerting-to-elasticsearch-node-rotation)