### PR TITLE
Add a new node into the ES cluster

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -136,6 +136,22 @@ Resources:
         Variables:
           ASG_NAME: !Sub ${AutoScalingGroupName}
 
+  ElasticsearchClusterSizeCheckLambda:
+    Type: "AWS::Lambda::Function"
+    DependsOn: NodeRotationLambdaRole
+    Properties:
+      FunctionName:
+          !Sub enr-elasticsearch-cluster-size-check
+      Description: "Confirms that the Elasticsearch cluster is the expected size"
+      Handler: "elasticsearchClusterSizeCheck.handler"
+      Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
+      Code:
+        S3Bucket: !Sub ${S3Bucket}
+        S3Key: !Sub ${S3Key}
+      MemorySize: 512
+      Runtime: nodejs8.10
+      Timeout: 300
+
   NodeRotationStepFunction:
     Type: "AWS::StepFunctions::StateMachine"
     DependsOn: ElasticsearchClusterStatusCheckLambda
@@ -177,7 +193,17 @@ Resources:
                "AddNewElasticsearchNode": {
                  "Type": "Task",
                  "Resource": "${AddElasticsearchNodeArn}",
-                 "End": true
+                 "Next": "ElasticsearchClusterSizeCheck"
+               },
+               "ElasticsearchClusterSizeCheck": {
+                 "Type": "Task",
+                 "Resource": "${ElasticsearchClusterSizeCheckArn}",
+                 "End": true,
+                 "Retry": [ {
+                   "ErrorEquals": [ "States.ALL" ],
+                   "IntervalSeconds": 10,
+                   "MaxAttempts": 12
+                  } ]
                }
              }
            }
@@ -185,4 +211,5 @@ Resources:
             GetOldestInstanceArn: !GetAtt GetOldestInstanceLambda.Arn
             StatuscheckArn: !GetAtt ElasticsearchClusterStatusCheckLambda.Arn
             AddElasticsearchNodeArn: !GetAtt AddElasticsearchNodeLambda.Arn
+            ElasticsearchClusterSizeCheckArn: !GetAtt ElasticsearchClusterSizeCheckLambda.Arn
       RoleArn: !GetAtt StatesExecutionRole.Arn

--- a/src/addElasticsearchNode.ts
+++ b/src/addElasticsearchNode.ts
@@ -11,7 +11,7 @@ export async function handler(event): Promise<AddElasticsearchNodeResponse> {
         const asg: string = process.env.ASG_NAME;
 
         const currentCapacity: Promise<number> = describeAsg(asg)
-            .then(asgInfo => handleAsgResponse(asgInfo));
+            .then(getDesiredCapacity);
 
         const disableRebalancing: Promise<{}> = updateRebalancingStatus(instanceId, "none")
             .then((result: StandardOutputContent) => {
@@ -51,7 +51,7 @@ function updateRebalancingStatus(instanceId: string, status: string): Promise<St
     return ssmCommand(elasticsearchCommand, instanceId);
 }
 
-export function handleAsgResponse(asgInfo: AutoScalingGroupsType): number {
+export function getDesiredCapacity(asgInfo: AutoScalingGroupsType): number {
     const asgsInResponse = asgInfo.AutoScalingGroups.length;
     if (asgsInResponse !== 1) {
         throw `Expected information about a single ASG, but got ${asgsInResponse}`;

--- a/src/addElasticsearchNode.ts
+++ b/src/addElasticsearchNode.ts
@@ -13,7 +13,7 @@ export async function handler(event): Promise<AddElasticsearchNodeResponse> {
         const currentCapacity: Promise<number> = describeAsg(asg)
             .then(asgInfo => handleAsgResponse(asgInfo));
 
-        const disableRebalancing = updateRebalancingStatus(instanceId, "none")
+        const disableRebalancing: Promise<{}> = updateRebalancingStatus(instanceId, "none")
             .then((result: StandardOutputContent) => {
                 const jsonResult = JSON.parse(result);
                 if (jsonResult.acknowledged != true) {
@@ -41,7 +41,7 @@ export async function handler(event): Promise<AddElasticsearchNodeResponse> {
 }
 
 function updateRebalancingStatus(instanceId: string, status: string): Promise<StandardOutputContent> {
-    const disableRebalancingCommand: Object =
+    const disableRebalancingCommand: object =
         {
             "persistent": {
                 "cluster.routing.rebalance.enable": status
@@ -53,7 +53,7 @@ function updateRebalancingStatus(instanceId: string, status: string): Promise<St
 
 export function handleAsgResponse(asgInfo: AutoScalingGroupsType): number {
     const asgsInResponse = asgInfo.AutoScalingGroups.length;
-    if (asgsInResponse != 1) {
+    if (asgsInResponse !== 1) {
         throw `Expected information about a single ASG, but got ${asgsInResponse}`;
     } else {
         return asgInfo.AutoScalingGroups[0].DesiredCapacity;

--- a/src/addElasticsearchNode.ts
+++ b/src/addElasticsearchNode.ts
@@ -16,7 +16,7 @@ export async function handler(event: ClusterStatusResponse): Promise<AddElastics
         const disableRebalancing: Promise<{}> = updateRebalancingStatus(instanceId, "none")
             .then((result: StandardOutputContent) => {
                 const jsonResult = JSON.parse(result);
-                if (jsonResult.acknowledged != true) {
+                if (jsonResult.acknowledged !== true) {
                     const error = `Unexpected Elasticsearch response, we got: ${JSON.stringify(jsonResult)}`;
                     reject(error);
                 } else {

--- a/src/addElasticsearchNode.ts
+++ b/src/addElasticsearchNode.ts
@@ -1,6 +1,49 @@
+import {ssmCommand} from './utils/ssmCommand';
+import {increaseAsgSize, describeAsg} from './utils/autoscaling';
+import {StandardOutputContent} from 'aws-sdk/clients/ssm';
+
 export async function handler(event) {
+
     return new Promise((resolve, reject) => {
-        resolve("done");
-    })
+        const instanceId: string = event.instanceId;
+        const asg: string = process.env.ASG_NAME;
+        const disableRebalancingCommand: Object =
+            {
+                "persistent": {
+                    "cluster.routing.rebalance.enable": "none"
+                }
+            };
+        const elasticsearchCommand = `curl -f -v -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d '${JSON.stringify(disableRebalancingCommand)}'`;
+
+        const currentCapacity: Promise<number> = describeAsg(asg)
+            .then(
+                asgInfo => {
+                    return asgInfo.AutoScalingGroups[0].DesiredCapacity;
+                }
+            );
+
+        const updateActions = ssmCommand(elasticsearchCommand, instanceId)
+            .then((result: StandardOutputContent) => {
+                const jsonResult = JSON.parse(result);
+                if (jsonResult.acknowledged != true) {
+                    const error = `Unexpected Elasticsearch response, we got: ${JSON.stringify(jsonResult)}`;
+                    reject(error);
+                }
+            })
+            .then(() => currentCapacity)
+            .then(capacity => {
+                return increaseAsgSize(asg, capacity);
+            });
+
+        return Promise.all([currentCapacity, updateActions])
+            .then(results => {
+                const response = {"instanceId": instanceId, "expectedClusterSize": results[0] + 1 };
+                resolve(response)
+            })
+            .catch(
+                error => reject(error)
+            )
+
+    });
 
 }

--- a/src/addElasticsearchNode.ts
+++ b/src/addElasticsearchNode.ts
@@ -18,7 +18,12 @@ export async function handler(event) {
         const currentCapacity: Promise<number> = describeAsg(asg)
             .then(
                 asgInfo => {
-                    return asgInfo.AutoScalingGroups[0].DesiredCapacity;
+                    const asgsInResponse = asgInfo.AutoScalingGroups.length;
+                    if (asgsInResponse != 1) {
+                        reject(`Expected information about a single ASG, but got ${asgsInResponse}`);
+                    } else {
+                        return asgInfo.AutoScalingGroups[0].DesiredCapacity;
+                    }
                 }
             );
 

--- a/src/addElasticsearchNode.ts
+++ b/src/addElasticsearchNode.ts
@@ -3,7 +3,7 @@ import {increaseAsgSize, describeAsg} from './utils/autoscaling';
 import {StandardOutputContent} from 'aws-sdk/clients/ssm';
 import {AutoScalingGroupsType} from "aws-sdk/clients/autoscaling";
 
-export async function handler(event): Promise<AddElasticsearchNodeResponse> {
+export async function handler(event: ClusterStatusResponse): Promise<AddElasticsearchNodeResponse> {
 
     return new Promise<AddElasticsearchNodeResponse>((resolve, reject) => {
 

--- a/src/addElasticsearchNode.ts
+++ b/src/addElasticsearchNode.ts
@@ -1,33 +1,19 @@
 import {ssmCommand} from './utils/ssmCommand';
 import {increaseAsgSize, describeAsg} from './utils/autoscaling';
 import {StandardOutputContent} from 'aws-sdk/clients/ssm';
+import {AutoScalingGroupsType} from "aws-sdk/clients/autoscaling";
 
 export async function handler(event): Promise<AddElasticsearchNodeResponse> {
 
     return new Promise<AddElasticsearchNodeResponse>((resolve, reject) => {
+
         const instanceId: string = event.instanceId;
         const asg: string = process.env.ASG_NAME;
-        const disableRebalancingCommand: Object =
-            {
-                "persistent": {
-                    "cluster.routing.rebalance.enable": "none"
-                }
-            };
-        const elasticsearchCommand = `curl -f -v -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d '${JSON.stringify(disableRebalancingCommand)}'`;
 
         const currentCapacity: Promise<number> = describeAsg(asg)
-            .then(
-                asgInfo => {
-                    const asgsInResponse = asgInfo.AutoScalingGroups.length;
-                    if (asgsInResponse != 1) {
-                        reject(`Expected information about a single ASG, but got ${asgsInResponse}`);
-                    } else {
-                        return asgInfo.AutoScalingGroups[0].DesiredCapacity;
-                    }
-                }
-            );
+            .then(asgInfo => handleAsgResponse(asgInfo));
 
-        const updateActions = ssmCommand(elasticsearchCommand, instanceId)
+        const disableRebalancing = updateRebalancingStatus(instanceId, "none")
             .then((result: StandardOutputContent) => {
                 const jsonResult = JSON.parse(result);
                 if (jsonResult.acknowledged != true) {
@@ -40,10 +26,10 @@ export async function handler(event): Promise<AddElasticsearchNodeResponse> {
                 return increaseAsgSize(asg, capacity);
             });
 
-        return Promise.all([currentCapacity, updateActions])
+        return Promise.all([currentCapacity, disableRebalancing])
             .then(results => {
-                const response: AddElasticsearchNodeResponse  = {"instanceId": instanceId, "expectedClusterSize": results[0] + 1 };
-                resolve(response)
+                const response: AddElasticsearchNodeResponse = {"instanceId": instanceId, "expectedClusterSize": results[0] + 1 };
+                resolve(response);
             })
             .catch(
                 error => reject(error)
@@ -51,4 +37,24 @@ export async function handler(event): Promise<AddElasticsearchNodeResponse> {
 
     });
 
+}
+
+function updateRebalancingStatus(instanceId: string, status: string): Promise<StandardOutputContent> {
+    const disableRebalancingCommand: Object =
+        {
+            "persistent": {
+                "cluster.routing.rebalance.enable": status
+            }
+        };
+    const elasticsearchCommand = `curl -f -v -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d '${JSON.stringify(disableRebalancingCommand)}'`;
+    return ssmCommand(elasticsearchCommand, instanceId);
+}
+
+export function handleAsgResponse(asgInfo: AutoScalingGroupsType): number {
+    const asgsInResponse = asgInfo.AutoScalingGroups.length;
+    if (asgsInResponse != 1) {
+        throw `Expected information about a single ASG, but got ${asgsInResponse}`;
+    } else {
+        return asgInfo.AutoScalingGroups[0].DesiredCapacity;
+    }
 }

--- a/src/addElasticsearchNode.ts
+++ b/src/addElasticsearchNode.ts
@@ -19,9 +19,10 @@ export async function handler(event): Promise<AddElasticsearchNodeResponse> {
                 if (jsonResult.acknowledged != true) {
                     const error = `Unexpected Elasticsearch response, we got: ${JSON.stringify(jsonResult)}`;
                     reject(error);
+                } else {
+                    return currentCapacity;
                 }
             })
-            .then(() => currentCapacity)
             .then(capacity => {
                 return increaseAsgSize(asg, capacity);
             });

--- a/src/elasticsearchClusterSizeCheck.ts
+++ b/src/elasticsearchClusterSizeCheck.ts
@@ -1,0 +1,23 @@
+import {ssmCommand} from './utils/ssmCommand';
+import {StandardOutputContent} from 'aws-sdk/clients/ssm';
+
+export async function handler(event): Promise<Object> {
+    return new Promise((resolve, reject) => {
+        ssmCommand('curl localhost:9200/_cluster/health', event.instanceId)
+            .then((result: StandardOutputContent) => {
+                const json = JSON.parse(result);
+                const nodesInCluster = json.number_of_nodes;
+                if (nodesInCluster == event.expectedClusterSize) {
+                    resolve({ "instanceId": event.instanceId })
+                } else {
+                    const error = `Found ${nodesInCluster} nodes but expected to find ${event.expectedClusterSize}`;
+                    console.log(error);
+                    reject(error)
+                }
+            })
+            .catch( error => {
+                console.log(error);
+                reject(error)
+            })
+    })
+}

--- a/src/elasticsearchClusterSizeCheck.ts
+++ b/src/elasticsearchClusterSizeCheck.ts
@@ -1,7 +1,7 @@
 import {ssmCommand} from './utils/ssmCommand';
 import {StandardOutputContent} from 'aws-sdk/clients/ssm';
 
-export async function handler(event): Promise<DefaultResponse> {
+export async function handler(event: AddElasticsearchNodeResponse): Promise<DefaultResponse> {
     return new Promise<DefaultResponse>((resolve, reject) => {
         ssmCommand('curl localhost:9200/_cluster/health', event.instanceId)
             .then((result: StandardOutputContent) => {

--- a/src/elasticsearchClusterSizeCheck.ts
+++ b/src/elasticsearchClusterSizeCheck.ts
@@ -1,14 +1,15 @@
 import {ssmCommand} from './utils/ssmCommand';
 import {StandardOutputContent} from 'aws-sdk/clients/ssm';
 
-export async function handler(event): Promise<Object> {
-    return new Promise((resolve, reject) => {
+export async function handler(event): Promise<DefaultResponse> {
+    return new Promise<DefaultResponse>((resolve, reject) => {
         ssmCommand('curl localhost:9200/_cluster/health', event.instanceId)
             .then((result: StandardOutputContent) => {
                 const json = JSON.parse(result);
                 const nodesInCluster = json.number_of_nodes;
-                if (nodesInCluster == event.expectedClusterSize) {
-                    resolve({ "instanceId": event.instanceId })
+                if (nodesInCluster === event.expectedClusterSize) {
+                    const response: DefaultResponse = { "instanceId": event.instanceId };
+                    resolve(response);
                 } else {
                     const error = `Found ${nodesInCluster} nodes but expected to find ${event.expectedClusterSize}`;
                     console.log(error);

--- a/src/handlerResponses.ts
+++ b/src/handlerResponses.ts
@@ -1,9 +1,11 @@
-interface ClusterStatusResponse {
+interface DefaultResponse {
     instanceId: string;
+}
+
+interface ClusterStatusResponse extends DefaultResponse {
     clusterStatus: string;
 }
 
-interface AddElasticsearchNodeResponse {
-    instanceId: string;
+interface AddElasticsearchNodeResponse extends DefaultResponse {
     expectedClusterSize: number;
 }

--- a/src/utils/ssmCommand.ts
+++ b/src/utils/ssmCommand.ts
@@ -10,7 +10,7 @@ export function ssmCommand(command: string, instanceId: string): Promise<Standar
             .then((commandId: string) => getCommandResult(commandId, instanceId))
             .then((result: SSM.Types.GetCommandInvocationResult) => {
                 if (result.Status === 'Success') resolve(result.StandardOutputContent);
-                else reject(`SSM command result was: ${result.Status} / ${result.StatusDetails}`)
+                else reject(`SSM command result was: ${result.Status} / ${result.StandardErrorContent}`)
             })
             .catch(reject)
     });

--- a/test/addElasticsearchNode.test.ts
+++ b/test/addElasticsearchNode.test.ts
@@ -1,0 +1,43 @@
+import { handleAsgResponse } from '../src/addElasticsearchNode'
+import {AutoScalingGroup, AutoScalingGroupsType} from "aws-sdk/clients/autoscaling";
+
+function asg(name: string, desiredCapacity: number): AutoScalingGroup {
+    return {
+        AutoScalingGroupName: name,
+        MinSize: 3,
+        MaxSize: 6,
+        DesiredCapacity: desiredCapacity,
+        DefaultCooldown: 1,
+        AvailabilityZones: [],
+        HealthCheckType: "none",
+        CreatedTime: new Date()
+    };
+}
+
+describe("handleAsgResponse", () => {
+    it("should throw an error if no ASG information is returned", () => {
+        const mock: AutoScalingGroupsType = {
+            AutoScalingGroups: []
+        };
+        expect(() => { handleAsgResponse(mock); }).toThrow()
+    });
+});
+
+describe("handleAsgResponse", () => {
+    it("should throw an error if information is returned about more than one ASG", () => {
+        const mock: AutoScalingGroupsType = {
+            AutoScalingGroups: [asg("asg123", 3), asg("asg124", 4)]
+        }
+        expect(() => { handleAsgResponse(mock); }).toThrow()
+    });
+});
+
+describe("handleAsgResponse", () => {
+    it("should return the desired capacity correctly if we get info about a single ASG", () => {
+        const desiredCapacity = 3;
+        const mock: AutoScalingGroupsType = {
+            AutoScalingGroups: [asg("asg123", desiredCapacity)]
+        }
+        expect(handleAsgResponse(mock)).toEqual(desiredCapacity);
+    });
+});

--- a/test/addElasticsearchNode.test.ts
+++ b/test/addElasticsearchNode.test.ts
@@ -1,4 +1,4 @@
-import { handleAsgResponse } from '../src/addElasticsearchNode'
+import { getDesiredCapacity } from '../src/addElasticsearchNode'
 import {AutoScalingGroup, AutoScalingGroupsType} from "aws-sdk/clients/autoscaling";
 
 function asg(name: string, desiredCapacity: number): AutoScalingGroup {
@@ -14,30 +14,30 @@ function asg(name: string, desiredCapacity: number): AutoScalingGroup {
     };
 }
 
-describe("handleAsgResponse", () => {
+describe("getDesiredCapacity", () => {
     it("should throw an error if no ASG information is returned", () => {
         const mock: AutoScalingGroupsType = {
             AutoScalingGroups: []
         };
-        expect(() => { handleAsgResponse(mock); }).toThrow()
+        expect(() => { getDesiredCapacity(mock); }).toThrow()
     });
 });
 
-describe("handleAsgResponse", () => {
+describe("getDesiredCapacity", () => {
     it("should throw an error if information is returned about more than one ASG", () => {
         const mock: AutoScalingGroupsType = {
             AutoScalingGroups: [asg("asg123", 3), asg("asg124", 4)]
         }
-        expect(() => { handleAsgResponse(mock); }).toThrow()
+        expect(() => { getDesiredCapacity(mock); }).toThrow()
     });
 });
 
-describe("handleAsgResponse", () => {
+describe("getDesiredCapacity", () => {
     it("should return the desired capacity correctly if we get info about a single ASG", () => {
         const desiredCapacity = 3;
         const mock: AutoScalingGroupsType = {
             AutoScalingGroups: [asg("asg123", desiredCapacity)]
         }
-        expect(handleAsgResponse(mock)).toEqual(desiredCapacity);
+        expect(getDesiredCapacity(mock)).toEqual(desiredCapacity);
     });
 });


### PR DESCRIPTION
This PR adds the real logic for the addElasticsearchNode lambda (a placeholder for this was added here: https://github.com/guardian/elasticsearch-node-rotation/pull/7/files).

It also adds a new lambda which checks that the new instance has actually joined the ES cluster successfully. We use the [step function retry rules](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-errors.html#amazon-states-language-retrying-after-error) to poll the cluster state using this new lambda.

Here's a nice diagram of a successful execution:

![image](https://user-images.githubusercontent.com/19384074/43517873-0ed88bf4-9582-11e8-8aa8-d9c888db57dc.png)
