### PR TITLE
Confirm that migrations are complete and remove the oldest node

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -187,6 +187,22 @@ Resources:
       Runtime: nodejs8.10
       Timeout: 300
 
+  RemoveNodeLambda:
+    Type: "AWS::Lambda::Function"
+    DependsOn: NodeRotationLambdaRole
+    Properties:
+      FunctionName:
+          !Sub enr-remove-node
+      Description: "Removes the oldest node in the cluster (and terminates the instance) before re-enabling re-balancing"
+      Handler: "removeNode.handler"
+      Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
+      Code:
+        S3Bucket: !Sub ${S3Bucket}
+        S3Key: !Sub ${S3Key}
+      MemorySize: 512
+      Runtime: nodejs8.10
+      Timeout: 300
+
   NodeRotationStepFunction:
     Type: "AWS::StepFunctions::StateMachine"
     DependsOn:
@@ -196,6 +212,7 @@ Resources:
     - ClusterSizeCheckLambda
     - MigrateShardsLambda
     - ShardMigrationCheckLambda
+    - RemoveNodeLambda
     Properties:
       DefinitionString:
         !Sub
@@ -255,14 +272,19 @@ Resources:
                "ShardMigrationCheck": {
                   "Type": "Task",
                   "Resource": "${ShardMigrationCheckArn}",
-                  "End": true,
+                  "Next": "RemoveNode",
                   "Retry": [ {
                     "ErrorEquals": [ "States.ALL" ],
                     "IntervalSeconds": 120,
                     "MaxAttempts": 60,
                     "BackoffRate": 1.0
                    } ]
-                }
+               },
+               "RemoveNode": {
+                 "Type": "Task",
+                 "Resource": "${RemoveNodeArn}",
+                 "End": true
+              }
              }
            }
           -
@@ -272,4 +294,5 @@ Resources:
             ClusterSizeCheckArn: !GetAtt ClusterSizeCheckLambda.Arn
             MigrateShardsArn: !GetAtt MigrateShardsLambda.Arn
             ShardMigrationCheckArn: !GetAtt ShardMigrationCheckLambda.Arn
+            RemoveNodeArn: !GetAtt RemoveNodeLambda.Arn
       RoleArn: !GetAtt StatesExecutionRole.Arn

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -171,6 +171,22 @@ Resources:
       Runtime: nodejs8.10
       Timeout: 300
 
+  ShardMigrationCheckLambda:
+    Type: "AWS::Lambda::Function"
+    DependsOn: NodeRotationLambdaRole
+    Properties:
+      FunctionName:
+          !Sub enr-shard-migration-check
+      Description: "Confirms that all shards have been migrated (and that cluster is green) or exits with an error"
+      Handler: "shardMigrationCheck.handler"
+      Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
+      Code:
+        S3Bucket: !Sub ${S3Bucket}
+        S3Key: !Sub ${S3Key}
+      MemorySize: 512
+      Runtime: nodejs8.10
+      Timeout: 300
+
   NodeRotationStepFunction:
     Type: "AWS::StepFunctions::StateMachine"
     DependsOn:
@@ -179,6 +195,7 @@ Resources:
     - AddNodeLambda
     - ClusterSizeCheckLambda
     - MigrateShardsLambda
+    - ShardMigrationCheckLambda
     Properties:
       DefinitionString:
         !Sub
@@ -225,15 +242,27 @@ Resources:
                  "Next": "MigrateShards",
                  "Retry": [ {
                    "ErrorEquals": [ "States.ALL" ],
-                   "IntervalSeconds": 10,
-                   "MaxAttempts": 12
+                   "IntervalSeconds": 30,
+                   "MaxAttempts": 20,
+                   "BackoffRate": 1.0
                   } ]
                },
                "MigrateShards": {
                   "Type": "Task",
                   "Resource": "${MigrateShardsArn}",
-                  "End": true
-               }
+                  "Next": "ShardMigrationCheck"
+               },
+               "ShardMigrationCheck": {
+                  "Type": "Task",
+                  "Resource": "${ShardMigrationCheckArn}",
+                  "End": true,
+                  "Retry": [ {
+                    "ErrorEquals": [ "States.ALL" ],
+                    "IntervalSeconds": 120,
+                    "MaxAttempts": 60,
+                    "BackoffRate": 1.0
+                   } ]
+                }
              }
            }
           -
@@ -242,4 +271,5 @@ Resources:
             AddNodeArn: !GetAtt AddNodeLambda.Arn
             ClusterSizeCheckArn: !GetAtt ClusterSizeCheckLambda.Arn
             MigrateShardsArn: !GetAtt MigrateShardsLambda.Arn
+            ShardMigrationCheckArn: !GetAtt ShardMigrationCheckLambda.Arn
       RoleArn: !GetAtt StatesExecutionRole.Arn

--- a/src/addNode.ts
+++ b/src/addNode.ts
@@ -1,5 +1,4 @@
 import {increaseAsgSize, describeAsg, getDesiredCapacity} from './aws/autoscaling';
-import {StandardOutputContent} from 'aws-sdk/clients/ssm';
 import {AddNodeResponse, ClusterStatusResponse} from './utils/handlerResponses';
 import {updateRebalancingStatus} from './elasticsearch/elasticsearch';
 
@@ -29,9 +28,10 @@ export async function handler(event: ClusterStatusResponse): Promise<AddNodeResp
                 };
                 resolve(response);
             })
-            .catch(
-                error => reject(error)
-            )
+            .catch(error => {
+                console.log(`Failed to add a new node due to: ${error}`);
+                reject(error)
+            })
 
     });
 

--- a/src/clusterSizeCheck.ts
+++ b/src/clusterSizeCheck.ts
@@ -32,7 +32,7 @@ export async function handler(event: AddNodeResponse): Promise<OldAndNewNodeResp
                 resolve(response);
             })
             .catch( error => {
-                console.log(error);
+                console.log(`Failed to get cluster status due to: ${error}`);
                 reject(error)
             })
     })

--- a/src/clusterSizeCheck.ts
+++ b/src/clusterSizeCheck.ts
@@ -1,10 +1,10 @@
-import {AddElasticsearchNodeResponse, ClusterSizeCheckResponse} from './utils/handlerResponses';
+import {AddNodeResponse, OldAndNewNodeResponse} from './utils/handlerResponses';
 import {getClusterHealth, getElasticsearchNode} from './elasticsearch/elasticsearch';
 import {getInstances, getSpecificInstance} from './aws/ec2Instances';
 import {ElasticsearchClusterStatus, ElasticsearchNode} from './elasticsearch/types';
 import {Instance} from './aws/types';
 
-export async function handler(event: AddElasticsearchNodeResponse): Promise<ClusterSizeCheckResponse> {
+export async function handler(event: AddNodeResponse): Promise<OldAndNewNodeResponse> {
 
     const asg: string = process.env.ASG_NAME;
 
@@ -12,7 +12,7 @@ export async function handler(event: AddElasticsearchNodeResponse): Promise<Clus
         .then(instances => getSpecificInstance(instances, findNewestInstance))
         .then(getElasticsearchNode);
 
-    return new Promise<ClusterSizeCheckResponse>((resolve, reject) => {
+    return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
         getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id)
             .then((clusterStatus: ElasticsearchClusterStatus) => {
                 const nodesInCluster = clusterStatus.number_of_nodes;
@@ -25,7 +25,7 @@ export async function handler(event: AddElasticsearchNodeResponse): Promise<Clus
                 }
             })
             .then( (newestElasticsearchNode: ElasticsearchNode) => {
-                const response: ClusterSizeCheckResponse = {
+                const response: OldAndNewNodeResponse = {
                     "oldestElasticsearchNode": event.oldestElasticsearchNode,
                     "newestElasticsearchNode": newestElasticsearchNode
                 };

--- a/src/clusterStatusCheck.ts
+++ b/src/clusterStatusCheck.ts
@@ -1,8 +1,8 @@
-import {ClusterStatusResponse, DefaultResponse} from './utils/handlerResponses';
+import {ClusterStatusResponse, OldestNodeResponse} from './utils/handlerResponses';
 import {getClusterHealth} from './elasticsearch/elasticsearch';
 import {ElasticsearchClusterStatus} from './elasticsearch/types';
 
-export async function handler(event: DefaultResponse): Promise<ClusterStatusResponse> {
+export async function handler(event: OldestNodeResponse): Promise<ClusterStatusResponse> {
     return getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id)
         .then( (clusterStatus: ElasticsearchClusterStatus) => {
             const response: ClusterStatusResponse = {

--- a/src/clusterStatusCheck.ts
+++ b/src/clusterStatusCheck.ts
@@ -3,12 +3,18 @@ import {getClusterHealth} from './elasticsearch/elasticsearch';
 import {ElasticsearchClusterStatus} from './elasticsearch/types';
 
 export async function handler(event: OldestNodeResponse): Promise<ClusterStatusResponse> {
-    return getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id)
-        .then( (clusterStatus: ElasticsearchClusterStatus) => {
-            const response: ClusterStatusResponse = {
-                "oldestElasticsearchNode": event.oldestElasticsearchNode,
-                "clusterStatus": clusterStatus.status
-            };
-            return response;
-        })
+    return new Promise<ClusterStatusResponse>((resolve, reject) => {
+        getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id)
+            .then( (clusterStatus: ElasticsearchClusterStatus) => {
+                const response: ClusterStatusResponse = {
+                    "oldestElasticsearchNode": event.oldestElasticsearchNode,
+                    "clusterStatus": clusterStatus.status
+                };
+                resolve(response);
+            })
+            .catch( error => {
+                console.log(`Failed to get cluster status due to: ${error}`);
+                reject(error)
+            })
+    })
 }

--- a/src/elasticsearch/elasticsearch.ts
+++ b/src/elasticsearch/elasticsearch.ts
@@ -81,7 +81,7 @@ export function migrateShards(moves: Move[], oldestElasticsearchNode: Elasticsea
 
 }
 
-function successfulAction(rawResponse: StandardOutputContent): Boolean {
+function successfulAction(rawResponse: StandardOutputContent): boolean {
     const jsonResult = JSON.parse(rawResponse);
     return jsonResult.acknowledged === true;
 }

--- a/src/elasticsearch/types.ts
+++ b/src/elasticsearch/types.ts
@@ -18,6 +18,26 @@ export class ElasticsearchNode {
 
 }
 
+export interface NodeStats {
+    nodes: NodeInfoObject
+}
+
+interface NodeInfoObject {
+    [key: string]: NodeInfo
+}
+
+interface NodeInfo {
+    indices: IndicesInfo
+}
+
+interface IndicesInfo {
+    docs: Documents
+}
+
+export interface Documents {
+    count: number
+}
+
 export interface ShardCopy {
     node: string;
     shard: number;

--- a/src/getOldestNode.ts
+++ b/src/getOldestNode.ts
@@ -15,7 +15,10 @@ export async function handler(event): Promise<OldestNodeResponse> {
                     "oldestElasticsearchNode": node
                 })
             })
-            .catch(error => reject(error))
+            .catch(error => {
+                console.log(`Failed to identify the oldest node in the cluster due to: ${error}`);
+                reject(error)
+            })
     })
 
 }

--- a/src/getOldestNode.ts
+++ b/src/getOldestNode.ts
@@ -1,10 +1,10 @@
-import {DefaultResponse} from './utils/handlerResponses';
+import {OldestNodeResponse} from './utils/handlerResponses';
 import {getInstances, getSpecificInstance} from './aws/ec2Instances';
 import {getElasticsearchNode} from './elasticsearch/elasticsearch';
 import {Instance} from './aws/types';
 
-export async function handler(event): Promise<DefaultResponse> {
-    return new Promise<DefaultResponse>((resolve, reject) => {
+export async function handler(event): Promise<OldestNodeResponse> {
+    return new Promise<OldestNodeResponse>((resolve, reject) => {
         const asg: string = process.env.ASG_NAME;
         console.log(`Searching for oldest node in ${asg}`);
         getInstances(asg)

--- a/src/migrateShards.ts
+++ b/src/migrateShards.ts
@@ -9,12 +9,9 @@ export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNo
         getShardInfo(oldestElasticsearchNode.ec2Instance.id)
             .then(response => moveInstructions(response, oldestElasticsearchNode, newestElasticsearchNode))
             .then(moves => migrateShards(moves, oldestElasticsearchNode))
-            .then(result => {
-                console.log(result);
-                resolve(event);
-            })
+            .then(() => resolve(event))
             .catch(error => {
-                console.log(`Failed to perform shard migration due to ${error}`)
+                console.log(`Failed to perform shard migration due to: ${error}`);
                 reject(error);
             });
     })

--- a/src/migrateShards.ts
+++ b/src/migrateShards.ts
@@ -1,13 +1,23 @@
-import {ClusterSizeCheckResponse, DefaultResponse} from './utils/handlerResponses';
+import {OldAndNewNodeResponse} from './utils/handlerResponses';
 import {getShardInfo, migrateShards} from './elasticsearch/elasticsearch';
 import {ElasticsearchNode, Move, ShardCopy} from './elasticsearch/types'
 
-export async function handler(event: ClusterSizeCheckResponse): Promise<DefaultResponse> {
+export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNodeResponse> {
     const oldestElasticsearchNode: ElasticsearchNode = event.oldestElasticsearchNode;
     const newestElasticsearchNode: ElasticsearchNode = event.newestElasticsearchNode;
-    return getShardInfo(oldestElasticsearchNode.ec2Instance.id)
-        .then(response => moveInstructions(response, oldestElasticsearchNode, newestElasticsearchNode))
-        .then(moves => migrateShards(moves, oldestElasticsearchNode));
+    return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
+        getShardInfo(oldestElasticsearchNode.ec2Instance.id)
+            .then(response => moveInstructions(response, oldestElasticsearchNode, newestElasticsearchNode))
+            .then(moves => migrateShards(moves, oldestElasticsearchNode))
+            .then(result => {
+                console.log(result);
+                resolve(event);
+            })
+            .catch(error => {
+                console.log(`Failed to perform shard migration due to ${error}`)
+                reject(error);
+            });
+    })
 }
 
 function moveInstructions(response, oldNode: ElasticsearchNode, newNode: ElasticsearchNode): Move[] {

--- a/src/removeNode.ts
+++ b/src/removeNode.ts
@@ -1,8 +1,6 @@
 import {OldAndNewNodeResponse} from './utils/handlerResponses';
 import {ssmCommand} from './utils/ssmCommand';
 import {terminateOldestInstance} from './aws/autoscaling';
-import {ActivityType} from 'aws-sdk/clients/autoscaling';
-import {StandardOutputContent} from 'aws-sdk/clients/ssm';
 import {updateRebalancingStatus} from "./elasticsearch/elasticsearch";
 
 export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNodeResponse> {
@@ -11,19 +9,11 @@ export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNo
 
     return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
         ssmCommand("systemctl stop elasticsearch", oldestInstanceId)
-                .then((result: StandardOutputContent) => {
-                    console.log(`Shutdown elasticsearch result: ${result}`);
-                    return terminateOldestInstance(oldestInstanceId);
-                })
-                .then((terminationResult: ActivityType) => {
-                    console.log(JSON.stringify(terminationResult));
-                    updateRebalancingStatus(event.newestElasticsearchNode.ec2Instance.id, "all");
-                })
-                .then(() => {
-                    resolve(event);
-                })
+                .then(() => terminateOldestInstance(oldestInstanceId))
+                .then(() => updateRebalancingStatus(event.newestElasticsearchNode.ec2Instance.id, "all"))
+                .then(() => resolve(event))
                 .catch(error => {
-                    const message = `Failed due to ${error}`;
+                    const message = `Failed due to terminate ${oldestInstanceId} due to: ${error}`;
                     console.log(message);
                     reject(message)
                 })

--- a/src/removeNode.ts
+++ b/src/removeNode.ts
@@ -1,0 +1,32 @@
+import {OldAndNewNodeResponse} from './utils/handlerResponses';
+import {ssmCommand} from './utils/ssmCommand';
+import {terminateOldestInstance} from './aws/autoscaling';
+import {ActivityType} from 'aws-sdk/clients/autoscaling';
+import {StandardOutputContent} from 'aws-sdk/clients/ssm';
+import {updateRebalancingStatus} from "./elasticsearch/elasticsearch";
+
+export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNodeResponse> {
+
+    const oldestInstanceId: string = event.oldestElasticsearchNode.ec2Instance.id;
+
+    return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
+        ssmCommand("systemctl stop elasticsearch", oldestInstanceId)
+                .then((result: StandardOutputContent) => {
+                    console.log(`Shutdown elasticsearch result: ${result}`);
+                    return terminateOldestInstance(oldestInstanceId);
+                })
+                .then((terminationResult: ActivityType) => {
+                    console.log(JSON.stringify(terminationResult));
+                    updateRebalancingStatus(event.newestElasticsearchNode.ec2Instance.id, "all");
+                })
+                .then(() => {
+                    resolve(event);
+                })
+                .catch(error => {
+                    const message = `Failed due to ${error}`;
+                    console.log(message);
+                    reject(message)
+                })
+    })
+
+}

--- a/src/shardMigrationCheck.ts
+++ b/src/shardMigrationCheck.ts
@@ -1,0 +1,22 @@
+import {DefaultResponse} from './utils/handlerResponses';
+import {getClusterHealth} from "./elasticsearch/elasticsearch";
+import {ElasticsearchClusterStatus} from "./elasticsearch/types";
+
+export async function handler(event: DefaultResponse): Promise<DefaultResponse> {
+    return new Promise<DefaultResponse>((resolve, reject) => {
+        getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id)
+            .then((clusterStatus: ElasticsearchClusterStatus) => {
+                if (clusterStatus.status === "green" && clusterStatus.relocating_shards === 0) {
+                    resolve(event)
+                } else {
+                    const error = `Check failed, cluster status is ${JSON.stringify(clusterStatus)}`;
+                    console.log(error);
+                    reject(error)
+                }
+            })
+            .catch( error => {
+                console.log(error);
+                reject(error)
+            })
+    })
+}

--- a/src/shardMigrationCheck.ts
+++ b/src/shardMigrationCheck.ts
@@ -1,6 +1,6 @@
 import {OldAndNewNodeResponse} from './utils/handlerResponses';
 import {getClusterHealth, getDocuments} from './elasticsearch/elasticsearch';
-import {ElasticsearchClusterStatus, Documents} from "./elasticsearch/types";
+import {ElasticsearchClusterStatus, Documents} from './elasticsearch/types';
 
 export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNodeResponse> {
     return new Promise<OldAndNewNodeResponse>((resolve, reject) => {

--- a/src/shardMigrationCheck.ts
+++ b/src/shardMigrationCheck.ts
@@ -1,15 +1,26 @@
-import {OldAndNewNodeResponse, OldestNodeResponse} from './utils/handlerResponses';
-import {getClusterHealth} from "./elasticsearch/elasticsearch";
-import {ElasticsearchClusterStatus} from "./elasticsearch/types";
+import {OldAndNewNodeResponse} from './utils/handlerResponses';
+import {getClusterHealth, getDocuments} from './elasticsearch/elasticsearch';
+import {ElasticsearchClusterStatus, Documents} from "./elasticsearch/types";
 
 export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNodeResponse> {
     return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
         getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id)
             .then((clusterStatus: ElasticsearchClusterStatus) => {
                 if (clusterStatus.status === "green" && clusterStatus.relocating_shards === 0) {
+                    console.log(`Cluster status is green and all shard relocations have finished`);
+                    return getDocuments(event.oldestElasticsearchNode);
+                } else {
+                    const error = `Migration check failed, cluster status is ${JSON.stringify(clusterStatus)}`;
+                    console.log(error);
+                    reject(error)
+                }
+            })
+            .then((documents: Documents) => {
+                if (documents.count === 0) {
+                    console.log(`There are no documents on ${JSON.stringify(event.oldestElasticsearchNode)}`);
                     resolve(event)
                 } else {
-                    const error = `Check failed, cluster status is ${JSON.stringify(clusterStatus)}`;
+                    const error = `Document check failed, there are still ${documents.count} on ${JSON.stringify(event.oldestElasticsearchNode)}`;
                     console.log(error);
                     reject(error)
                 }

--- a/src/shardMigrationCheck.ts
+++ b/src/shardMigrationCheck.ts
@@ -1,9 +1,9 @@
-import {DefaultResponse} from './utils/handlerResponses';
+import {OldAndNewNodeResponse, OldestNodeResponse} from './utils/handlerResponses';
 import {getClusterHealth} from "./elasticsearch/elasticsearch";
 import {ElasticsearchClusterStatus} from "./elasticsearch/types";
 
-export async function handler(event: DefaultResponse): Promise<DefaultResponse> {
-    return new Promise<DefaultResponse>((resolve, reject) => {
+export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNodeResponse> {
+    return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
         getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id)
             .then((clusterStatus: ElasticsearchClusterStatus) => {
                 if (clusterStatus.status === "green" && clusterStatus.relocating_shards === 0) {

--- a/src/utils/handlerResponses.ts
+++ b/src/utils/handlerResponses.ts
@@ -1,17 +1,17 @@
 import {ElasticsearchNode} from '../elasticsearch/types'
 
-export interface DefaultResponse {
+export interface OldestNodeResponse {
     oldestElasticsearchNode: ElasticsearchNode;
 }
 
-export interface ClusterStatusResponse extends DefaultResponse {
+export interface OldAndNewNodeResponse extends OldestNodeResponse {
+    newestElasticsearchNode: ElasticsearchNode;
+}
+
+export interface ClusterStatusResponse extends OldestNodeResponse {
     clusterStatus: string;
 }
 
-export interface AddElasticsearchNodeResponse extends DefaultResponse {
+export interface AddNodeResponse extends OldestNodeResponse {
     expectedClusterSize: number;
-}
-
-export interface ClusterSizeCheckResponse extends DefaultResponse {
-    newestElasticsearchNode: ElasticsearchNode;
 }


### PR DESCRIPTION
This PR:

* Adds two new lambdas: one which polls until the shard migrations are complete, another to actually perform the final steps of safely removing the old node (and killing the instance).
* Adds numerous logging improvements - to make it easier to debug issues.
* Adds a check to ensure that all Elasticsearch update actions (i.e. PUTs and POSTs) are correctly acknowledged.