### PR TITLE
Fix issue with exclusion settings reset

### DIFF
--- a/src/removeNode.ts
+++ b/src/removeNode.ts
@@ -7,11 +7,12 @@ import {excludeFromAllocation} from "./elasticsearch/elasticsearch";
 export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNodeResponse> {
 
     const oldestInstance: Instance = event.oldestElasticsearchNode.ec2Instance;
+    const newestInstance: Instance = event.newestElasticsearchNode.ec2Instance;
 
     return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
         ssmCommand("systemctl stop elasticsearch", oldestInstance.id, false)
                 .then(() => terminateInstance(oldestInstance))
-                .then(() => excludeFromAllocation("", oldestInstance.id)) // Don't exclude any ips
+                .then(() => excludeFromAllocation("", newestInstance.id)) // Don't exclude any ips
                 .then(() => resolve(event))
                 .catch(error => {
                     const message = `Failed due to terminate ${oldestInstance.id} due to: ${error}`;


### PR DESCRIPTION
Unsurprisingly, trying to run ES commands against a terminating instance, which isn't running ES, doesn't work.