### PR TITLE
Extend polling period for shard migration

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -317,7 +317,7 @@ Resources:
                   "Retry": [ {
                     "ErrorEquals": [ "States.ALL" ],
                     "IntervalSeconds": 120,
-                    "MaxAttempts": 60,
+                    "MaxAttempts": 120,
                     "BackoffRate": 1.0
                    } ]
                },


### PR DESCRIPTION
It currently takes quite a long time for the migration process to complete for Central ELK.