### PR TITLE
Pass ASG Name to lambda as event input

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -122,7 +122,6 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          ASG_NAME: !Ref AutoScalingGroupName
           SSM_BUCKET_NAME: !Ref SsmOutputBucketName
 
   GetOldestNodeLambda:
@@ -142,7 +141,6 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          ASG_NAME: !Ref AutoScalingGroupName
           SSM_BUCKET_NAME: !Ref SsmOutputBucketName
 
   AddNodeLambda:
@@ -162,7 +160,6 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          ASG_NAME: !Ref AutoScalingGroupName
           SSM_BUCKET_NAME: !Ref SsmOutputBucketName
 
   ClusterSizeCheckLambda:
@@ -182,7 +179,6 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          ASG_NAME: !Ref AutoScalingGroupName
           SSM_BUCKET_NAME: !Ref SsmOutputBucketName
 
   MigrateShardsLambda:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -368,6 +368,10 @@ Resources:
       Targets:
       - Arn: !Ref NodeRotationStepFunction
         Id: !GetAtt NodeRotationStepFunction.Name
+        Input: !Sub |
+          {
+            "asgName": "${AutoScalingGroupName}"
+          }
         RoleArn: !GetAtt TriggerExecutionRole.Arn
     DependsOn:
     - NodeRotationStepFunction

--- a/src/addNode.ts
+++ b/src/addNode.ts
@@ -1,5 +1,5 @@
 import {detachInstance} from './aws/autoscaling';
-import {AddNodeResponse, ClusterStatusResponse} from './utils/handlerResponses';
+import {AddNodeResponse, ClusterStatusResponse} from './utils/handlerInputs';
 import {getClusterHealth, updateRebalancingStatus} from './elasticsearch/elasticsearch';
 import {Instance} from './aws/types';
 import {ElasticsearchClusterStatus} from './elasticsearch/types';
@@ -7,7 +7,7 @@ import {ElasticsearchClusterStatus} from './elasticsearch/types';
 export async function handler(event: ClusterStatusResponse): Promise<AddNodeResponse> {
 
     const oldestInstance: Instance = event.oldestElasticsearchNode.ec2Instance;
-    const asg: string = process.env.ASG_NAME;
+    const asg: string = event.asgName;
 
     return new Promise<AddNodeResponse>((resolve, reject) => {
         updateRebalancingStatus(oldestInstance.id, "none")
@@ -15,6 +15,7 @@ export async function handler(event: ClusterStatusResponse): Promise<AddNodeResp
             .then(() => getClusterHealth(oldestInstance.id))
             .then((clusterStatus: ElasticsearchClusterStatus) => {
                 const response: AddNodeResponse = {
+                    "asgName": asg,
                     "oldestElasticsearchNode": event.oldestElasticsearchNode,
                     "expectedClusterSize": clusterStatus.number_of_nodes + 1
                 };

--- a/src/clusterSizeCheck.ts
+++ b/src/clusterSizeCheck.ts
@@ -1,4 +1,4 @@
-import {AddNodeResponse, OldAndNewNodeResponse} from './utils/handlerResponses';
+import {AddNodeResponse, OldAndNewNodeResponse} from './utils/handlerInputs';
 import {getClusterHealth, getElasticsearchNode} from './elasticsearch/elasticsearch';
 import {getInstances, getSpecificInstance} from './aws/ec2Instances';
 import {ElasticsearchClusterStatus, ElasticsearchNode} from './elasticsearch/types';
@@ -6,7 +6,7 @@ import {Instance} from './aws/types';
 
 export async function handler(event: AddNodeResponse): Promise<OldAndNewNodeResponse> {
 
-    const asg: string = process.env.ASG_NAME;
+    const asg: string = event.asgName;
 
     const newestNode: Promise<ElasticsearchNode> = getInstances(asg)
         .then(instances => getSpecificInstance(instances, findNewestInstance))
@@ -26,6 +26,7 @@ export async function handler(event: AddNodeResponse): Promise<OldAndNewNodeResp
             })
             .then( (newestElasticsearchNode: ElasticsearchNode) => {
                 const response: OldAndNewNodeResponse = {
+                    "asgName": asg,
                     "oldestElasticsearchNode": event.oldestElasticsearchNode,
                     "newestElasticsearchNode": newestElasticsearchNode
                 };

--- a/src/getOldestNode.ts
+++ b/src/getOldestNode.ts
@@ -1,17 +1,18 @@
-import {OldestNodeResponse} from './utils/handlerResponses';
+import {OldestNodeResponse} from './utils/handlerInputs';
 import {getInstances, getSpecificInstance} from './aws/ec2Instances';
 import {getElasticsearchNode} from './elasticsearch/elasticsearch';
 import {Instance} from './aws/types';
 
 export async function handler(event): Promise<OldestNodeResponse> {
     return new Promise<OldestNodeResponse>((resolve, reject) => {
-        const asg: string = process.env.ASG_NAME;
+        const asg: string = event.asgName;
         console.log(`Searching for oldest node in ${asg}`);
         getInstances(asg)
             .then(instances => getSpecificInstance(instances, findOldestInstance))
             .then(getElasticsearchNode)
             .then(node => {
                 resolve({
+                    asgName: asg,
                     "oldestElasticsearchNode": node
                 })
             })

--- a/src/migrateShards.ts
+++ b/src/migrateShards.ts
@@ -1,4 +1,4 @@
-import {OldAndNewNodeResponse} from './utils/handlerResponses';
+import {OldAndNewNodeResponse} from './utils/handlerInputs';
 import {
     excludeFromAllocation,
     updateRebalancingStatus

--- a/src/removeNode.ts
+++ b/src/removeNode.ts
@@ -1,4 +1,4 @@
-import {OldAndNewNodeResponse} from './utils/handlerResponses';
+import {OldAndNewNodeResponse} from './utils/handlerInputs';
 import {ssmCommand} from './utils/ssmCommand';
 import {terminateInstance} from "./aws/ec2Instances";
 import {Instance} from './aws/types';

--- a/src/shardMigrationCheck.ts
+++ b/src/shardMigrationCheck.ts
@@ -1,4 +1,4 @@
-import {OldAndNewNodeResponse} from './utils/handlerResponses';
+import {OldAndNewNodeResponse} from './utils/handlerInputs';
 import {getClusterHealth, getDocuments} from './elasticsearch/elasticsearch';
 import {ElasticsearchClusterStatus, Documents} from './elasticsearch/types';
 

--- a/src/utils/handlerInputs.ts
+++ b/src/utils/handlerInputs.ts
@@ -1,6 +1,10 @@
 import {ElasticsearchNode} from '../elasticsearch/types'
 
-export interface OldestNodeResponse {
+export interface StateMachineInput {
+    asgName: string
+}
+
+export interface OldestNodeResponse extends StateMachineInput {
     oldestElasticsearchNode: ElasticsearchNode;
 }
 


### PR DESCRIPTION
Instead of using an environment variable.

This will allow us to invoke the Step Function against different ASGs, depending on the input event. This means that we will be able to cater for ES clusters with dedicated master nodes (once I've made the relevant CFN updates).