### PR TITLE
Prevent concurrent node rotations

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -367,12 +367,16 @@ Resources:
       State: ENABLED
       Targets:
       - Arn: !Ref NodeRotationStepFunction
-        Id: !GetAtt NodeRotationStepFunction.Name
-        Input: !Sub |
-          {
-            "asgName": "${AutoScalingGroupName}"
-          }
         RoleArn: !GetAtt TriggerExecutionRole.Arn
+        Id: !GetAtt NodeRotationStepFunction.Name
+        Input: !Sub
+          - |
+            {
+              "asgName": "${AutoScalingGroupName}",
+              "stepFunctionArn": "${StepFunctionArn}"
+            }
+          -
+            StepFunctionArn: !Ref NodeRotationStepFunction
     DependsOn:
     - NodeRotationStepFunction
     - TriggerExecutionRole

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -86,6 +86,12 @@ Resources:
                 Action: s3:GetObject
                 Resource:
                 - !Sub arn:aws:s3:::${SsmOutputBucketName}/*
+        - PolicyName: QueryStepFunctionHistory
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: states:ListExecutions
+                Resource: "*"
 
   StatesExecutionRole:
     Type: "AWS::IAM::Role"

--- a/src/aws/stepFunctions.ts
+++ b/src/aws/stepFunctions.ts
@@ -1,0 +1,23 @@
+import { ListExecutionsInput, ListExecutionsOutput } from 'aws-sdk/clients/stepfunctions';
+
+const AWS = require('aws-sdk');
+const awsStepFunctions = new AWS.StepFunctions;
+
+export function totalRunningExecutions(stepFunctionArn: string): Promise<number> {
+    const params: ListExecutionsInput = {
+        stateMachineArn: stepFunctionArn,
+        statusFilter: 'RUNNING'
+    };
+    const requestPromise: Promise<ListExecutionsOutput> = awsStepFunctions.listExecutions(params).promise();
+    return new Promise<number>((resolve, reject) => {
+        requestPromise.then(
+            function (data: ListExecutionsOutput) {
+                resolve(data.executions.length);
+            },
+            function (error) {
+                console.log(error, error.stack, error.statusCode);
+                reject(error);
+            }
+        );
+    })
+}

--- a/src/utils/handlerInputs.ts
+++ b/src/utils/handlerInputs.ts
@@ -1,10 +1,14 @@
 import {ElasticsearchNode} from '../elasticsearch/types'
 
-export interface StateMachineInput {
-    asgName: string
+export interface StateMachineInput extends AsgInput {
+    stepFunctionArn: string;
 }
 
-export interface OldestNodeResponse extends StateMachineInput {
+export interface AsgInput {
+    asgName: string;
+}
+
+export interface OldestNodeResponse extends AsgInput {
     oldestElasticsearchNode: ElasticsearchNode;
 }
 


### PR DESCRIPTION
We never want to run more than one node rotation at a time (for the same Elasticsearch cluster), because this would potentially cause us to make conflicting updates to ES cluster settings and/or ASG capacity settings. 

Currently we rely on sensible scheduling and timeout rules to 'enforce' this principle, which is obviously not particularly robust. This PR ensures that we fail a Step Function execution (during the first task) if another execution is already in progress.

When implementing this safety check, I also considered:

1. Setting a concurrent execution limit in AWS

_Sadly this does not seem to be possible (as far as I can tell it's possible to set concurrent execution limits for lambdas, but not for Step Functions)._

2. Tagging the ASGs which comprise the ES cluster

_There didn't seem to be any obvious benefits to this (over the approach used in this PR), and it adds a little complexity (lambdas need to know about all of the ASGs which comprise the ES cluster, we need more code to untag the ASGs at the end of the node rotation)._