### PR TITLE
Handle dedicated master nodes

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -378,18 +378,36 @@ Resources:
             RemoveNodeArn: !GetAtt RemoveNodeLambda.Arn
       RoleArn: !GetAtt StatesExecutionRole.Arn
 
-  NodeRotationSchedule:
+  DataNodeRotationSchedule:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub node-rotation-schedule-${ClusterName}
-      ScheduleExpression: !Ref CronExpression
+      Name: !Sub data-node-rotation-schedule-${ClusterName}
+      ScheduleExpression: !Ref DataNodeRotationCronExpression
       State: ENABLED
       Targets:
       - Arn: !Ref NodeRotationStepFunction
         Id: !GetAtt NodeRotationStepFunction.Name
         Input: !Sub |
           {
-            "asgName": "${AutoScalingGroupName}"
+            "asgName": "${DataNodeAsg}"
+          }
+        RoleArn: !GetAtt TriggerExecutionRole.Arn
+    DependsOn:
+    - NodeRotationStepFunction
+    - TriggerExecutionRole
+
+  MasterNodeRotationSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub master-node-rotation-schedule-${ClusterName}
+      ScheduleExpression: !Ref MasterNodeRotationCronExpression
+      State: ENABLED
+      Targets:
+      - Arn: !Ref NodeRotationStepFunction
+        Id: !GetAtt NodeRotationStepFunction.Name
+        Input: !Sub |
+          {
+            "asgName": "${DedicatedMasterAsg}"
           }
         RoleArn: !GetAtt TriggerExecutionRole.Arn
     DependsOn:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -397,6 +397,7 @@ Resources:
     - TriggerExecutionRole
 
   MasterNodeRotationSchedule:
+    Condition: HasDedicatedMasters
     Type: AWS::Events::Rule
     Properties:
       Name: !Sub master-node-rotation-schedule-${ClusterName}

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -5,25 +5,31 @@ Description: "Step Function for rotating Elasticsearch nodes"
 Parameters:
   Stage:
     Type: String
-    Description: Stage name
+    Description: Stage name.
   DeployS3Bucket:
     Type: String
-    Description: Bucket which contains .zip file used by lambda functions e.g. deploy-tools-dist
+    Description: Bucket which contains .zip file used by lambda functions e.g. deploy-tools-dist.
   DeployS3Key:
     Type: String
-    Description: Key for .zip file used by lambda functions e.g. <stack>/<stage>/elasticsearch-node-rotation/elasticsearch-node-rotation.zip
-  AutoScalingGroupName:
+    Description: Key for .zip file used by lambda functions e.g. <stack>/<stage>/elasticsearch-node-rotation/elasticsearch-node-rotation.zip.
+  DataNodeAsg:
     Type: String
-    Description: The name of the auto-scaling group which contains the Elasticsearch nodes
+    Description: The name of the auto-scaling group which contains the Elasticsearch data nodes (which may also be masters).
+  DedicatedMasterAsg:
+    Type: String
+    Description: The name of the auto-scaling group which contains dedicated Elasticsearch master nodes. Leave this field empty if the Elasticsearch cluster does not have dedicated master nodes.
   SsmOutputBucketName:
     Type: String
     Description: Bucket used to store SSM command output. This bucket must already exist and the instances which receive SSM commands must have PutObject permissions for this bucket.
   SNSTopicForAlerts:
     Type: String
-    Description: The name of the SNS topic used for alerting in the case of a failed rotation attempt
+    Description: The name of the SNS topic used for alerting in the case of a failed rotation attempt.
   ClusterName:
     Type: String
-    Description: The name of the elasticsearch cluster, for context in alerts
+    Description: The name of the elasticsearch cluster, for context in alerts.
+
+Conditions:
+  HasDedicatedMasters: !Not [!Equals [!Ref DedicatedMasterAsg, '']]
 
 Resources:
 
@@ -63,7 +69,17 @@ Resources:
               - Effect: Allow
                 Action:
                 - autoscaling:DetachInstances
-                Resource: !Sub arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AutoScalingGroupName}
+                Resource:
+                  - !Sub arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${DataNodeAsg}
+              - !If
+                  - HasDedicatedMasters
+                  -
+                    Effect: Allow
+                    Action:
+                    - autoscaling:DetachInstances
+                    Resource:
+                    - !Sub arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${DedicatedMasterAsg}
+                  - !Ref AWS::NoValue
         - PolicyName: ElasticsearchAdminSsmPolicy
           PolicyDocument:
             Statement:
@@ -122,7 +138,6 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          ASG_NAME: !Ref AutoScalingGroupName
           SSM_BUCKET_NAME: !Ref SsmOutputBucketName
 
   GetOldestNodeLambda:
@@ -142,7 +157,6 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          ASG_NAME: !Ref AutoScalingGroupName
           SSM_BUCKET_NAME: !Ref SsmOutputBucketName
 
   AddNodeLambda:
@@ -162,7 +176,6 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          ASG_NAME: !Ref AutoScalingGroupName
           SSM_BUCKET_NAME: !Ref SsmOutputBucketName
 
   ClusterSizeCheckLambda:
@@ -182,7 +195,6 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          ASG_NAME: !Ref AutoScalingGroupName
           SSM_BUCKET_NAME: !Ref SsmOutputBucketName
 
   MigrateShardsLambda:


### PR DESCRIPTION
This adds the necessary permissions and schedule to rotate dedicated master nodes which belong to a separate ASG (e.g. https://github.com/guardian/deploy-tools-platform/blob/master/cloudformation/elk.template.yaml#L435-L450). 