### PR TITLE
Ensure EC2 instances are not gone for long from Auto-Scaling Group

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -70,11 +70,12 @@ Resources:
                 Action:
                 - autoscaling:DescribeAutoScalingGroups
                 - ec2:DescribeInstances
-                - ec2:TerminateInstances
                 Resource: "*"
               - Effect: Allow
                 Action:
                 - autoscaling:DetachInstances
+                - autoscaling:AttachInstances
+                - autoscaling:TerminateInstanceInAutoScalingGroup
                 Resource:
                   - !Sub arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${DataNodeAsg}
               - !If
@@ -83,6 +84,8 @@ Resources:
                     Effect: Allow
                     Action:
                     - autoscaling:DetachInstances
+                    - autoscaling:AttachInstances
+                    - autoscaling:TerminateInstanceInAutoScalingGroup
                     Resource:
                     - !Sub arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${DedicatedMasterAsg}
                   - !Ref AWS::NoValue
@@ -231,6 +234,25 @@ Resources:
         Variables:
           SSM_BUCKET_NAME: !Ref SsmOutputBucketName
 
+  ReattachOldInstanceLambda:
+    Type: "AWS::Lambda::Function"
+    DependsOn: NodeRotationLambdaRole
+    Properties:
+      FunctionName:
+        !Sub enr-reattach-old-instance-${Stage}
+      Description: "Reattaches old instance to the ASG"
+      Handler: "reattachOldInstance.handler"
+      Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
+      Code:
+        S3Bucket: !Sub ${DeployS3Bucket}
+        S3Key: !Sub ${DeployS3Key}
+      MemorySize: 512
+      Runtime: nodejs8.10
+      Timeout: 300
+      Environment:
+        Variables:
+          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+
   MigrateShardsLambda:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
@@ -295,6 +317,7 @@ Resources:
     - ClusterStatusCheckLambda
     - AddNodeLambda
     - ClusterSizeCheckLambda
+    - ReattachOldInstanceLambda
     - MigrateShardsLambda
     - ShardMigrationCheckLambda
     - RemoveNodeLambda
@@ -343,7 +366,7 @@ Resources:
                "ClusterSizeCheck": {
                  "Type": "Task",
                  "Resource": "${ClusterSizeCheckArn}",
-                 "Next": "MigrateShards",
+                 "Next": "ReattachOldInstance",
                  "Retry": [ {
                    "ErrorEquals": [ "States.ALL" ],
                    "IntervalSeconds": 30,
@@ -351,6 +374,11 @@ Resources:
                    "BackoffRate": 1.0
                   } ]
                },
+               "ReattachOldInstance": {
+                  "Type": "Task",
+                  "Resource": "${ReattachOldInstanceArn}",
+                  "Next": "MigrateShards"
+                },
                "MigrateShards": {
                   "Type": "Task",
                   "Resource": "${MigrateShardsArn}",
@@ -379,6 +407,7 @@ Resources:
             ClusterStatusCheckArn: !GetAtt ClusterStatusCheckLambda.Arn
             AddNodeArn: !GetAtt AddNodeLambda.Arn
             ClusterSizeCheckArn: !GetAtt ClusterSizeCheckLambda.Arn
+            ReattachOldInstanceArn: !GetAtt ReattachOldInstanceLambda.Arn
             MigrateShardsArn: !GetAtt MigrateShardsLambda.Arn
             ShardMigrationCheckArn: !GetAtt ShardMigrationCheckLambda.Arn
             RemoveNodeArn: !GetAtt RemoveNodeLambda.Arn

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -37,7 +37,7 @@ deployments:
   ophan-enr-cloudformation:
     stacks: [ophan]
     template: cloudformation
-    app: elk-data-node-rotation
+    app: ophan-es-node-rotation
   ophan-enr-lambda:
     stacks: [ophan]
     dependencies: [ophan-enr-cloudformation]

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -17,6 +17,7 @@ templates:
       - enr-get-oldest-node-
       - enr-add-node-
       - enr-cluster-size-check-
+      - enr-reattach-old-instance-
       - enr-migrate-shards-
       - enr-shard-migration-check-
       - enr-remove-node-

--- a/src/aws/autoscaling.ts
+++ b/src/aws/autoscaling.ts
@@ -15,6 +15,21 @@ export function detachInstance(instance: Instance, asgName: string): Promise<Det
     return awsAutoscaling.detachInstances(params).promise()
 }
 
+export function attachInstance(instance: Instance, asgName: string): Promise<{}> {
+    console.log(`Attaching ${instance.id} to ${asgName}.`);
+    const params = {
+        InstanceIds: [ instance.id ],
+        AutoScalingGroupName: asgName
+    };
+    return awsAutoscaling.attachInstances(params).promise()
+}
+
+export function terminateInstanceInASG(instance: Instance): Promise<AutoScaling.Types.ActivityType> {
+    console.log(`Terminating instance ${instance.id}`);
+    const params = { InstanceId: instance.id, ShouldDecrementDesiredCapacity: true };
+    return awsAutoscaling.terminateInstanceInAutoScalingGroup(params).promise()
+}
+
 export function describeAsg(asgName: string): Promise<AutoScaling.Types.AutoScalingGroupsType> {
     const params = { AutoScalingGroupNames: [ asgName ] };
     return awsAutoscaling.describeAutoScalingGroups(params).promise();

--- a/src/aws/ec2Instances.ts
+++ b/src/aws/ec2Instances.ts
@@ -22,12 +22,6 @@ export function getInstances(asgName: string): Promise<string[]> {
     )
 }
 
-export function terminateInstance(instance: Instance): Promise<TerminateInstancesResult> {
-    console.log(`Terminating instance ${instance.id}`);
-    const params = { InstanceIds: [ instance.id ] };
-    return awsEc2.terminateInstances(params).promise()
-}
-
 export function getSpecificInstance(instanceIds: string[], instanceFilter: InstanceFilter): Promise<Instance> {
     console.log(`Fetching details for: ${instanceIds}`);
     const params = { InstanceIds: instanceIds };

--- a/src/reattachOldInstance.ts
+++ b/src/reattachOldInstance.ts
@@ -1,0 +1,21 @@
+import {attachInstance} from './aws/autoscaling';
+import {OldAndNewNodeResponse} from './utils/handlerInputs';
+import {Instance} from './aws/types';
+
+export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNodeResponse> {
+
+    const oldestInstance: Instance = event.oldestElasticsearchNode.ec2Instance;
+    const asg: string = event.asgName;
+
+    return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
+        attachInstance(oldestInstance, asg)
+            .then( () => {
+                resolve(event);
+            })
+            .catch(error => {
+                console.log(`Failed to reattach old instance: ${error}`);
+                reject(error);
+            })
+    })
+
+}

--- a/src/removeNode.ts
+++ b/src/removeNode.ts
@@ -1,6 +1,6 @@
 import {OldAndNewNodeResponse} from './utils/handlerInputs';
 import {ssmCommand} from './utils/ssmCommand';
-import {terminateInstance} from "./aws/ec2Instances";
+import {terminateInstanceInASG} from "./aws/autoscaling";
 import {Instance} from './aws/types';
 import {excludeFromAllocation} from "./elasticsearch/elasticsearch";
 
@@ -11,7 +11,7 @@ export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNo
 
     return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
         ssmCommand("systemctl stop elasticsearch", oldestInstance.id, false)
-                .then(() => terminateInstance(oldestInstance))
+                .then(() => terminateInstanceInASG(oldestInstance))
                 .then(() => excludeFromAllocation("", newestInstance.id)) // Don't exclude any ips
                 .then(() => resolve(event))
                 .catch(error => {


### PR DESCRIPTION
This helps reduce confusion when developers are trying to work out how many operational nodes they have (I personally tend to check the ASG to see all my active boxes) - the change in this commit ensures that we re-attach the 'old' node to the ASG, once we're sure (thanks to `ClusterSizeCheck`) that the ASG has brought up a 'new' node.

It also means that the ENR lambdas no longer need to be granted the general `ec2:TerminateInstances` permission - instead they just have the `autoscaling:TerminateInstanceInAutoScalingGroup`, which is restricted so they can only kill instances in that particular ASG, rather than in any EC2 instance in the AWS account.

See also guardian/ophan#2745
