### PR TITLE
Don't wait for irrelevant shard reallocations to complete

### DIFF
--- a/src/elasticsearch/elasticsearch.ts
+++ b/src/elasticsearch/elasticsearch.ts
@@ -22,7 +22,8 @@ export function getElasticsearchNode(instance: Instance): Promise<ElasticsearchN
             const json = JSON.parse(result);
             if (json._nodes.total === 1) {
                 const nodeId: string = Object.keys(json.nodes)[0];
-                return new ElasticsearchNode(instance, nodeId);
+                const isMaster: boolean = json.nodes[nodeId].settings.node.master == 'true';
+                return new ElasticsearchNode(instance, nodeId, isMaster);
             } else {
                 throw `expected information about a single node, but got: ${JSON.stringify(json)}`;
             }

--- a/src/elasticsearch/types.ts
+++ b/src/elasticsearch/types.ts
@@ -10,10 +10,12 @@ export class ElasticsearchNode {
 
     ec2Instance: Instance;
     nodeId: string;
+    isMasterEligible: boolean;
 
-    constructor(instance: Instance, nodeId: string) {
+    constructor(instance: Instance, nodeId: string, isMasterEligible) {
         this.ec2Instance = instance;
         this.nodeId = nodeId;
+        this.isMasterEligible = isMasterEligible
     }
 
 }

--- a/src/shardMigrationCheck.ts
+++ b/src/shardMigrationCheck.ts
@@ -8,11 +8,11 @@ export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNo
     ]).then(([clusterStatus, documents]) => {
         const hasDocuments = documents.count > 0;
         const isMasterAndShardsRelocating = event.oldestElasticsearchNode.isMasterEligible && clusterStatus.relocating_shards > 0;
-        const isClusterNotGreen = !(clusterStatus.status === "green");
+        const clusterIsUnhealthy = !(clusterStatus.status === "green");
 
-        if (isClusterNotGreen || hasDocuments || isMasterAndShardsRelocating) {
+        if (clusterIsUnhealthy || hasDocuments || isMasterAndShardsRelocating) {
             const error =
-                `Check failed: hasDocuments=${hasDocuments} isMasterAndShardsRelocating=${isMasterAndShardsRelocating} isClusterNotGreen=${isClusterNotGreen}`;
+                `Check failed: hasDocuments=${hasDocuments} isMasterAndShardsRelocating=${isMasterAndShardsRelocating} clusterIsUnhealthy=${clusterIsUnhealthy}`;
             console.log(error);
             throw new Error(error);
         } else return event;

--- a/src/shardMigrationCheck.ts
+++ b/src/shardMigrationCheck.ts
@@ -1,33 +1,20 @@
 import {OldAndNewNodeResponse} from './utils/handlerInputs';
 import {getClusterHealth, getDocuments} from './elasticsearch/elasticsearch';
-import {ElasticsearchClusterStatus, Documents} from './elasticsearch/types';
 
 export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNodeResponse> {
-    return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
-        getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id)
-            .then((clusterStatus: ElasticsearchClusterStatus) => {
-                if (clusterStatus.status === "green" && clusterStatus.relocating_shards === 0) {
-                    console.log(`Cluster status is green and all shard relocations have finished`);
-                    return getDocuments(event.oldestElasticsearchNode);
-                } else {
-                    const error = `Migration check failed, cluster status is ${JSON.stringify(clusterStatus)}`;
-                    console.log(error);
-                    reject(error)
-                }
-            })
-            .then((documents: Documents) => {
-                if (documents.count === 0) {
-                    console.log(`There are no documents on ${JSON.stringify(event.oldestElasticsearchNode)}`);
-                    resolve(event)
-                } else {
-                    const error = `Document check failed, there are still ${documents.count} on ${JSON.stringify(event.oldestElasticsearchNode)}`;
-                    console.log(error);
-                    reject(error)
-                }
-            })
-            .catch( error => {
-                console.log(error);
-                reject(error)
-            })
-    })
+    return Promise.all([
+        getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id),
+        getDocuments(event.oldestElasticsearchNode)
+    ]).then(([clusterStatus, documents]) => {
+        const hasDocuments = documents.count > 0;
+        const isMasterAndShardsRelocating = event.oldestElasticsearchNode.isMasterEligible && clusterStatus.relocating_shards > 0;
+        const isClusterNotGreen = !(clusterStatus.status === "green");
+
+        if (isClusterNotGreen || hasDocuments || isMasterAndShardsRelocating) {
+            const error =
+                `Check failed: hasDocuments=${hasDocuments} isMasterAndShardsRelocating=${isMasterAndShardsRelocating} isClusterNotGreen=${isClusterNotGreen}`;
+            console.log(error);
+            throw new Error(error);
+        } else return event;
+    });
 }


### PR DESCRIPTION
This fixes issue #31, and also improves the error logging produced by the `shardMigrationCheck`.

A non-Master node (eg a Data Node) can be killed if:

* it has no Documents
* [slightly paranoid] it is excluded from shard allocation

We know that the 2nd condition is already true as we've executed the `MigrateShards` step, and if the 1st condition is true, we should proceed and kill the box - it **doesn't matter** if other shard reallocations are taking place.

On our Ophan cluster, we find that shard reallocations can continue for hours after the old cluster is completely empty, so waiting for _no_ reallocations to be taking place can actually time-out the ENP
step-function.


