### PR TITLE
Ensure delay/failure of shutdown doesn't prevent termination of instance

### DIFF
--- a/src/removeNode.ts
+++ b/src/removeNode.ts
@@ -9,16 +9,16 @@ export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNo
     const oldestInstance: Instance = event.oldestElasticsearchNode.ec2Instance;
     const newestInstance: Instance = event.newestElasticsearchNode.ec2Instance;
 
-    return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
-        ssmCommand("systemctl stop elasticsearch", oldestInstance.id, false)
-                .then(() => terminateInstanceInASG(oldestInstance))
-                .then(() => excludeFromAllocation("", newestInstance.id)) // Don't exclude any ips
-                .then(() => resolve(event))
-                .catch(error => {
-                    const message = `Failed due to terminate ${oldestInstance.id} due to: ${error}`;
-                    console.log(message);
-                    reject(message)
-                })
-    })
+    if (event.oldestElasticsearchNode.isMasterEligible) try {
+        await ssmCommand("systemctl stop elasticsearch", oldestInstance.id, false);
+    } catch(error) {
+        console.log(`Will still attempt to terminate ${oldestInstance.id} after best effort at gentle shutdown not completed due to: ${error}`);
+    }
 
+    await Promise.all([
+        terminateInstanceInASG(oldestInstance),
+        excludeFromAllocation("", newestInstance.id) // Don't exclude any ips
+    ]);
+
+    return event;
 }


### PR DESCRIPTION
We've seen a [couple](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/arn:aws:states:eu-west-1:021353022223:execution:Elasticsearch-Node-Rotation-ophan:1708eb8f-ebfa-d2dd-ce2a-b447db9ca124_b3c27646-f5a9-de39-49d4-fe0540e77743) of [times](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/arn:aws:states:eu-west-1:021353022223:execution:Elasticsearch-Node-Rotation-ophan:65c6b368-2a87-88e2-7ac6-1e9ddfcacd45_2f7dce95-85ab-2f4e-c516-879771e168f3) that the Step Function has not terminated the old instance, due to a sluggish response on the systemd shutdown:

![image](https://user-images.githubusercontent.com/52038/51904044-8e99af00-23b5-11e9-922d-1b117f500442.png)


https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logEventViewer:group=/aws/lambda/enr-remove-node-PROD;stream=2019/01/24/[$LATEST]79dbdedef6b74c98849a0439a9501b8e;start=2019-01-23T15:24:09Z

```
15:24:09
2019-01-24T15:24:09.347Z	c69e513f-adb4-4f85-94c8-0abd59719ebb
Failed due to terminate i-0f88ebbef0f4b7bc8 due to: SSM command result was: InProgress /

15:24:09
2019-01-24T15:24:09.349Z	c69e513f-adb4-4f85-94c8-0abd59719ebb
{
    "errorMessage": "Failed due to terminate i-0f88ebbef0f4b7bc8 due to: SSM command result was: InProgress / "
}
```

Note that the systemd shutdown didn't even fail, it's just 'in progress'. My belief is that the systemd shutdown is a nice-to-have if we already know that the node contains no data - for an empty data node we could just kill it already, for an elected master node it *is* good to attempt a shutdown as this appears to improve the speed of master re-election - but I'm not convinced that even then it's worth leaving the instance running - we're paying for this instance to carry on running doing nothing!

![image](https://user-images.githubusercontent.com/52038/51904205-f819bd80-23b5-11e9-8e81-5c681186adbb.png)


Consequently, the change in this commit means that we only attempt a systemd shutdown if the node is master-eligible - and even then, we don't let it stop the termination of the instance.

