### PR TITLE
Parameterise IAM policy name

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -42,7 +42,7 @@ Resources:
   NodeRotationLambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub NodeRotation
+      RoleName: !Sub ${ClusterName}-NodeRotation-${Stage}
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow


### PR DESCRIPTION
At the moment it's not possible to create multiple instances of node rotation in the same account. We want to make both a `TEST` and `PROD` stage instance.