### PR TITLE
Fix ssm failure due to the 'In-Progress' race condition 

### DIFF
--- a/src/utils/ssmCommand.ts
+++ b/src/utils/ssmCommand.ts
@@ -9,7 +9,7 @@ export function ssmCommand(command: string, instanceId: string, outputExpected: 
     return new Promise<string>((resolve, reject) => {
         sendCommand(command, instanceId)
             .then(delay)
-            .then((sendResult: SSM.Types.SendCommandResult) => awaitCommandResult(sendResult.Command.CommandId, instanceId, 3))
+            .then((sendResult: SSM.Types.SendCommandResult) => awaitCommandResult(sendResult.Command.CommandId, instanceId, 6))
             .then((result: SSM.Types.GetCommandInvocationResult) => {
                 if (result.Status === 'Success' && outputExpected) return (result.StandardOutputUrl);
                 else if (result.Status === 'Success' && !outputExpected) resolve("success");

--- a/src/utils/ssmCommand.ts
+++ b/src/utils/ssmCommand.ts
@@ -8,23 +8,17 @@ const s3 = new AWS.S3();
 export function ssmCommand(command: string, instanceId: string, outputExpected: boolean = true): Promise<string> {
     return new Promise<string>((resolve, reject) => {
         sendCommand(command, instanceId)
-            .then((sendResult: SSM.Types.SendCommandResult) => wait(10000, sendResult.Command.CommandId))
-            .then((commandId: string) => getCommandResult(commandId, instanceId))
+            .then(delay)
+            .then((sendResult: SSM.Types.SendCommandResult) => awaitCommandResult(sendResult.Command.CommandId, instanceId, 3))
             .then((result: SSM.Types.GetCommandInvocationResult) => {
                 if (result.Status === 'Success' && outputExpected) return (result.StandardOutputUrl);
                 else if (result.Status === 'Success' && !outputExpected) resolve("success");
                 else reject(`SSM command result was: ${result.Status} / ${result.StandardErrorContent}`)
             })
-            .then((url: Url) => wait(10000, url))
+            .then(delay)
             .then(getResultFromS3)
             .then((result: GetObjectOutput) => resolve(result.Body.toString()))
             .catch(reject)
-    });
-}
-
-function wait(millis: number, value) {
-    return new Promise((resolve, reject) => {
-        setTimeout(() => resolve(value), millis)
     });
 }
 
@@ -41,6 +35,29 @@ function sendCommand(command, instanceId): Promise<SSM.Types.SendCommandResult> 
         ],
         OutputS3BucketName: process.env.SSM_BUCKET_NAME
     }).promise();
+}
+
+function delay(value) {
+    return new Promise((resolve) => {
+       setTimeout(() => resolve(value), 10000)
+    });
+}
+
+const terminalState = new Set(['Success', 'TimedOut', 'Failed', 'Cancelled']);
+
+function awaitCommandResult(commandId: string, instanceId: string, remainingRetries: number): Promise<SSM.Types.GetCommandInvocationResult> {
+    return getCommandResult(commandId, instanceId)
+        .then((result: SSM.Types.GetCommandInvocationResult) => {
+            if (terminalState.has(result.Status) || remainingRetries <= 0) {
+                console.log(`Final state: ${result.Status}; remaining retries: ${remainingRetries}`);
+                return result;
+            } else {
+                console.log(`Retrying getCommandResult. Current state: ${result.Status}; remaining retries: ${remainingRetries}`);
+                return new Promise(res => setTimeout(res, 10000)).then(() => {
+                    return awaitCommandResult(commandId, instanceId, remainingRetries-1)
+                });
+            }
+        });
 }
 
 function getCommandResult(commandId, instanceId): Promise<SSM.Types.GetCommandInvocationResult> {


### PR DESCRIPTION
This addresses #36, by retrying the `getCommandResult` function either 3 times or until we reach a terminal state, as outlined in the [AWS JavaScript SDK documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SSM.html#sendCommand-property) for SSM. 

We were able to reproduce the issue seen in #36 by introducing a 15 second sleep to the sending of the `ssmCommand`, which failed with a `Failed to identify the oldest node in the cluster due to: SSM command result was: InProgress /` error message:

![Screenshot 2019-08-07 at 11 42 28](https://user-images.githubusercontent.com/23078809/62618434-1be13180-b90c-11e9-828f-fbd241d358d1.png)

Keeping the sleep but including the code changes in this PR, we see that our `awaitCommandResult` accounts for this and results in a successful run of the step function, despite encountering non-terminal states:

![Screenshot 2019-08-07 at 12 12 31](https://user-images.githubusercontent.com/23078809/62618654-a88bef80-b90c-11e9-8a70-49014230942f.png)

We've also slightly refactored the `wait` function to take fewer parameters. 