### PR TITLE
WIP: add logging to make it clearer where the RemoveNode step fails

### DIFF
--- a/src/removeNode.ts
+++ b/src/removeNode.ts
@@ -10,6 +10,7 @@ export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNo
     const newestInstance: Instance = event.newestElasticsearchNode.ec2Instance;
 
     if (event.oldestElasticsearchNode.isMasterEligible) try {
+        console.log(`attempting to terminate oldestInstance: ${oldestInstance.id}`);
         await ssmCommand("systemctl stop elasticsearch", oldestInstance.id, false);
     } catch(error) {
         console.log(`Will still attempt to terminate ${oldestInstance.id} after best effort at gentle shutdown not completed due to: ${error}`);

--- a/src/removeNode.ts
+++ b/src/removeNode.ts
@@ -10,7 +10,7 @@ export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNo
     const newestInstance: Instance = event.newestElasticsearchNode.ec2Instance;
 
     if (event.oldestElasticsearchNode.isMasterEligible) try {
-        console.log(`attempting to terminate oldestInstance: ${oldestInstance.id}`);
+        console.log(`attempting to smoothly shutdown master-eligible node: ${oldestInstance.id}`);
         await ssmCommand("systemctl stop elasticsearch", oldestInstance.id, false);
     } catch(error) {
         console.log(`Will still attempt to terminate ${oldestInstance.id} after best effort at gentle shutdown not completed due to: ${error}`);

--- a/src/utils/ssmCommand.ts
+++ b/src/utils/ssmCommand.ts
@@ -13,7 +13,7 @@ export function ssmCommand(command: string, instanceId: string, outputExpected: 
             .then((result: SSM.Types.GetCommandInvocationResult) => {
                 if (result.Status === 'Success' && outputExpected) return (result.StandardOutputUrl);
                 else if (result.Status === 'Success' && !outputExpected) resolve("success");
-                else reject(`SSM command result was: ${result.Status} / ${result.StandardErrorContent}`)
+                else reject(`SSM command: ${command} result was: ${result.Status} / ${result.StandardErrorContent}`)
             })
             .then(delay)
             .then(getResultFromS3)
@@ -23,6 +23,7 @@ export function ssmCommand(command: string, instanceId: string, outputExpected: 
 }
 
 function sendCommand(command, instanceId): Promise<SSM.Types.SendCommandResult> {
+        console.log(`sending SSM command: ${command} for instance: ${instanceId}`);
     return ssm.sendCommand({
         DocumentName: 'AWS-RunShellScript',
         Parameters: {

--- a/src/utils/ssmCommand.ts
+++ b/src/utils/ssmCommand.ts
@@ -13,7 +13,7 @@ export function ssmCommand(command: string, instanceId: string, outputExpected: 
             .then((result: SSM.Types.GetCommandInvocationResult) => {
                 if (result.Status === 'Success' && outputExpected) return (result.StandardOutputUrl);
                 else if (result.Status === 'Success' && !outputExpected) resolve("success");
-                else reject(`SSM command: ${command} result was: ${result.Status} / ${result.StandardErrorContent}`)
+                else reject(`SSM command executed on ${instanceId} not successfully completed. status='${result.Status}' errorContent='${result.StandardErrorContent}' command='${command}'`)
             })
             .then(delay)
             .then(getResultFromS3)


### PR DESCRIPTION
We had the RemoveNode step function fail for us this morning, and it was unclear what had failed from the logs:

![image](https://user-images.githubusercontent.com/9820960/65249230-811f6980-daeb-11e9-9c91-8f1aeaa15468.png)

It wasn't clear that the command had been sent to terminate the oldest node, but the problem was with waiting for the result of the command to be a 'terminalState' (not 'InProgress').

The command did eventually reach a terminal state, so there wasn't any action for us to take, but some more verbose logging might have helped us realise this quicker.