### PR TITLE
Handle AWS API throttling in ASG scaling

### DIFF
--- a/src/utils/helperFunctions.ts
+++ b/src/utils/helperFunctions.ts
@@ -1,0 +1,23 @@
+export function delay<T>(value: T): Promise<T> {
+    return new Promise<T>((resolve) => {
+       setTimeout(() => resolve(value), 15000)
+    });
+}
+
+export function retry<T>(fn:()=> Promise<T>, taskName: string, remainingRetries: number): Promise<T> {
+    console.log(`Number of retries remaining ${remainingRetries} when ${taskName}`)
+    return fn()
+    .then((res) => {
+        console.log(`Succeeded when ${taskName}`)
+        return res
+    })
+    .catch((err) =>{
+        console.error(`Failed when ${taskName} with :\n${err}`)
+        if (remainingRetries>0) {
+            return delay({}).then(() => retry(fn, taskName, remainingRetries-1))
+        } else {
+            console.error(`Ran out of retries when ${taskName}`)
+            return Promise.reject(err)
+        }
+    })
+}

--- a/src/utils/ssmCommand.ts
+++ b/src/utils/ssmCommand.ts
@@ -1,6 +1,7 @@
 import SSM = require('aws-sdk/clients/ssm');
 import {Url} from 'aws-sdk/clients/ssm';
 import {GetObjectOutput} from "aws-sdk/clients/s3";
+import{delay} from "../utils/helperFunctions";
 const AWS = require('aws-sdk');
 const ssm = new AWS.SSM();
 const s3 = new AWS.S3();
@@ -36,12 +37,6 @@ function sendCommand(command, instanceId): Promise<SSM.Types.SendCommandResult> 
         ],
         OutputS3BucketName: process.env.SSM_BUCKET_NAME
     }).promise();
-}
-
-function delay(value) {
-    return new Promise((resolve) => {
-       setTimeout(() => resolve(value), 10000)
-    });
 }
 
 const terminalState = new Set(['Success', 'TimedOut', 'Failed', 'Cancelled']);


### PR DESCRIPTION
This addresses https://github.com/guardian/elasticsearch-node-rotation/issues/45.

Code is added to handle retrying failed AWS API calls, specifically
those that deal with attaching and detaching instances from ASGs.
We already have code to retry SSM commands but a different approach
is required when using the AWS API directly.

A `retry` function has been added that accepts a function (typically
anonymous) that will  produce the expected `Promise<T>` and that
can be called a  fixed number of times. After this `retry` will throw an
error that is handled by the AWS lambda runtime.

Co-authored-by: Roberto Tyley <roberto.tyley@guardian.co.uk>