### PR TITLE
Add initial ASG group check to avoid adding nodes to cluster without also removing a node

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -195,6 +195,25 @@ Resources:
         Variables:
           SSM_BUCKET_NAME: !Ref SsmOutputBucketName
 
+  AutoScalingGroupCheckLambda:
+    Type: "AWS::Lambda::Function"
+    DependsOn: NodeRotationLambdaRole
+    Properties:
+      FunctionName:
+        !Sub enr-auto-scaling-group-check-${Stage}
+      Description: "Checks that a single Auto Scaling Group is returned with a maximum limit greater than the desired capacity"
+      Handler: "autoScalingGroupCheck.handler"
+      Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
+      Code:
+        S3Bucket: !Sub ${DeployS3Bucket}
+        S3Key: !Sub ${DeployS3Key}
+      MemorySize: 512
+      Runtime: nodejs10.x
+      Timeout: 300
+      Environment:
+        Variables:
+          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+
   GetOldestNodeLambda:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
@@ -331,6 +350,7 @@ Resources:
   NodeRotationStepFunction:
     Type: "AWS::StepFunctions::StateMachine"
     DependsOn:
+    - AutoScalingGroupCheckLambda
     - GetOldestNodeLambda
     - ClusterStatusCheckLambda
     - AddNodeLambda
@@ -347,8 +367,13 @@ Resources:
           - |
            {
              "Comment": "Elasticsearch Node Rotation",
-             "StartAt": "GetOldestNode",
+             "StartAt": "AutoScalingGroupCheck",
              "States": {
+               "AutoScalingGroupCheck": {
+                 "Type": "Task",
+                 "Resource": "${AutoScalingGroupCheckArn}",
+                 "Next": "GetOldestNode"
+                },
                "GetOldestNode": {
                  "Type": "Task",
                  "Resource": "${GetOldestNodeArn}",
@@ -421,6 +446,7 @@ Resources:
              }
            }
           -
+            AutoScalingGroupCheckArn: !GetAtt AutoScalingGroupCheckLambda.Arn
             GetOldestNodeArn: !GetAtt GetOldestNodeLambda.Arn
             ClusterStatusCheckArn: !GetAtt ClusterStatusCheckLambda.Arn
             AddNodeArn: !GetAtt AddNodeLambda.Arn

--- a/src/autoScalingGroupCheck.ts
+++ b/src/autoScalingGroupCheck.ts
@@ -2,10 +2,8 @@ import {
     AutoScalingGroupCheckResponse,
     StateMachineInput
 } from './utils/handlerInputs';
-import {describeAsg} from "./aws/autoscaling";
+import {describeAsg, singleASG} from "./aws/autoscaling";
 import {totalRunningExecutions} from "./aws/stepFunctions";
-import {AutoScalingGroup, AutoScalingGroups} from "aws-sdk/clients/autoscaling";
-
 
 export async function handler(event: StateMachineInput): Promise<AutoScalingGroupCheckResponse> {
     try {
@@ -41,14 +39,5 @@ export async function handler(event: StateMachineInput): Promise<AutoScalingGrou
     } catch (error) {
         console.log(`Failing Step Function execution; ${error}`)
         throw error
-    }
-}
-
-export function singleASG(groups: AutoScalingGroups): AutoScalingGroup {
-    const groupNumber = groups.length;
-    if (groupNumber !== 1) {
-        throw new Error(`Expected single ASG, but got ${groupNumber}`)
-    } else {
-        return groups[0]
     }
 }

--- a/src/autoScalingGroupCheck.ts
+++ b/src/autoScalingGroupCheck.ts
@@ -1,0 +1,54 @@
+import {
+    AutoScalingGroupCheckResponse,
+    StateMachineInput
+} from './utils/handlerInputs';
+import {describeAsg} from "./aws/autoscaling";
+import {totalRunningExecutions} from "./aws/stepFunctions";
+import {AutoScalingGroup, AutoScalingGroups} from "aws-sdk/clients/autoscaling";
+
+
+export async function handler(event: StateMachineInput): Promise<AutoScalingGroupCheckResponse> {
+    try {
+        const runningExecutionsPromise = totalRunningExecutions(event.stepFunctionArn)
+        const runningExecutions = await runningExecutionsPromise
+
+        if (runningExecutions !== 1) {
+            const error = `Expected to find one running execution (this one!) but there were ${runningExecutions}.`
+            throw new Error(error)
+        }
+
+        const asgPromise = describeAsg(event.asgName)
+        const asgs = await asgPromise
+        const singleAsg = singleASG(asgs.AutoScalingGroups)
+
+        if (singleAsg.MaxSize == singleAsg.DesiredCapacity) {
+            const error = `ASG MaxSize must be greater than Desired Capacity to allow for ReattachOldInstance step.`
+            throw new Error(error)
+        }
+
+        const instanceIds = singleAsg.Instances.map(i  => i.InstanceId)
+        const unhealthyInstanceCount = singleAsg.Instances.filter(i => i.HealthStatus !== 'Healthy').length
+
+        if (unhealthyInstanceCount > 0) {
+            const error = `ASG has ${unhealthyInstanceCount} unhealthy instances`;
+            throw new Error(error)
+        }
+
+        return ({
+            asgName: event.asgName,
+            instanceIds: instanceIds
+        })
+    } catch (error) {
+        console.log(`Failing Step Function execution; ${error}`)
+        throw error
+    }
+}
+
+export function singleASG(groups: AutoScalingGroups): AutoScalingGroup {
+    const groupNumber = groups.length;
+    if (groupNumber !== 1) {
+        throw new Error(`Expected single ASG, but got ${groupNumber}`)
+    } else {
+        return groups[0]
+    }
+}

--- a/src/aws/autoscaling.ts
+++ b/src/aws/autoscaling.ts
@@ -1,5 +1,5 @@
 import {AutoScaling} from 'aws-sdk';
-import {DetachInstancesAnswer} from 'aws-sdk/clients/autoscaling';
+import {AutoScalingGroup, AutoScalingGroups, DetachInstancesAnswer} from 'aws-sdk/clients/autoscaling';
 import {Instance} from './types';
 import {retry} from '../utils/helperFunctions';
 
@@ -37,4 +37,13 @@ export function terminateInstanceInASG(instance: Instance): Promise<AutoScaling.
 export function describeAsg(asgName: string): Promise<AutoScaling.Types.AutoScalingGroupsType> {
     const params = { AutoScalingGroupNames: [ asgName ] };
     return retry(() => awsAutoscaling.describeAutoScalingGroups(params).promise(), `describing ASG ${asgName}`, 5)
+}
+
+export function singleASG(groups: AutoScalingGroups): AutoScalingGroup {
+    const groupNumber = groups.length;
+    if (groupNumber !== 1) {
+        throw new Error(`Expected single ASG, but got ${groupNumber}`)
+    } else {
+        return groups[0]
+    }
 }

--- a/src/aws/autoscaling.ts
+++ b/src/aws/autoscaling.ts
@@ -1,5 +1,5 @@
 import {AutoScaling} from 'aws-sdk';
-import {AutoScalingGroupsType, DetachInstancesAnswer} from 'aws-sdk/clients/autoscaling';
+import {DetachInstancesAnswer} from 'aws-sdk/clients/autoscaling';
 import {Instance} from './types';
 import {retry} from '../utils/helperFunctions';
 
@@ -37,13 +37,4 @@ export function terminateInstanceInASG(instance: Instance): Promise<AutoScaling.
 export function describeAsg(asgName: string): Promise<AutoScaling.Types.AutoScalingGroupsType> {
     const params = { AutoScalingGroupNames: [ asgName ] };
     return retry(() => awsAutoscaling.describeAutoScalingGroups(params).promise(), `describing ASG ${asgName}`, 5)
-}
-
-export function getDesiredCapacity(asgInfo: AutoScalingGroupsType): number {
-    const asgsInResponse = asgInfo.AutoScalingGroups.length;
-    if (asgsInResponse !== 1) {
-        throw `Expected information about a single ASG, but got ${asgsInResponse}`;
-    } else {
-        return asgInfo.AutoScalingGroups[0].DesiredCapacity;
-    }
 }

--- a/src/aws/ec2Instances.ts
+++ b/src/aws/ec2Instances.ts
@@ -8,20 +8,6 @@ const awsEc2 = new AWS.EC2();
 
 type InstanceFilter = (instances: Instance[]) => Instance;
 
-export function getInstances(asgName: string): Promise<string[]> {
-    const autoScalingRequest = describeAsg(asgName);
-    return autoScalingRequest.then(
-        function (data: AutoScalingGroupsType) {
-            const instances = data.AutoScalingGroups[0].Instances;
-            return instances.map(instance => instance.InstanceId);
-        },
-        function (error) {
-            console.log(error, error.stack, error.statusCode);
-            return error;
-        }
-    )
-}
-
 export function getSpecificInstance(instanceIds: string[], instanceFilter: InstanceFilter): Promise<Instance> {
     console.log(`Fetching details for: ${instanceIds}`);
     const params = { InstanceIds: instanceIds };

--- a/src/clusterSizeCheck.ts
+++ b/src/clusterSizeCheck.ts
@@ -3,11 +3,10 @@ import {getClusterHealth, getElasticsearchNode} from './elasticsearch/elasticsea
 import {getSpecificInstance} from './aws/ec2Instances';
 import {ElasticsearchClusterStatus, ElasticsearchNode} from './elasticsearch/types';
 import {Instance} from './aws/types';
-import {describeAsg} from "./aws/autoscaling";
-import {singleASG} from "./autoScalingGroupCheck";
+import {describeAsg, singleASG} from "./aws/autoscaling";
 
 export async function handler(event: AddNodeResponse): Promise<OldAndNewNodeResponse> {
-    
+
     const asgs = await describeAsg(event.asgName)
     const singleAsg = singleASG(asgs.AutoScalingGroups)
     const instanceIds = singleAsg.Instances.map(i  => i.InstanceId)

--- a/src/clusterStatusCheck.ts
+++ b/src/clusterStatusCheck.ts
@@ -1,33 +1,18 @@
 import {ClusterStatusResponse, OldestNodeResponse} from './utils/handlerInputs';
 import {getClusterHealth} from './elasticsearch/elasticsearch';
-import {ElasticsearchClusterStatus} from './elasticsearch/types';
-import {describeAsg} from "./aws/autoscaling";
-import {AutoScalingGroupsType} from "aws-sdk/clients/autoscaling";
 
 export async function handler(event: OldestNodeResponse): Promise<ClusterStatusResponse> {
-    return new Promise<ClusterStatusResponse>((resolve, reject) => {
-        Promise.all([
-            describeAsg(event.asgName),
-            getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id)
-        ]).then(([asg, clusterStatus]: [AutoScalingGroupsType, ElasticsearchClusterStatus]) => {
-            const unhealthyInstanceCount: number = asg.AutoScalingGroups[0].Instances.filter(i => i.HealthStatus !== 'Healthy').length;
+    try {
+        const clusterStatus = await getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id)
 
-            if (unhealthyInstanceCount === 0) {
-                const response: ClusterStatusResponse = {
-                    "asgName": event.asgName,
-                    "oldestElasticsearchNode": event.oldestElasticsearchNode,
-                    "clusterStatus": clusterStatus.status
-                };
-                resolve(response);
-            } else {
-                const error = `ASG has ${unhealthyInstanceCount} unhealthy instances`;
-                console.log(error);
-                reject(error)
-            }
+        return ({
+            "asgName": event.asgName,
+            "oldestElasticsearchNode": event.oldestElasticsearchNode,
+            "clusterStatus": clusterStatus.status
         })
-        .catch( error => {
-            console.log(`Failed to get cluster status due to: ${error}`);
-            reject(error)
-        })
-    })
+    } catch (error) {
+        console.log(`Failed to get cluster status due to: ${error}`)
+        throw(error)
+    }
+
 }

--- a/src/utils/handlerInputs.ts
+++ b/src/utils/handlerInputs.ts
@@ -8,6 +8,10 @@ export interface AsgInput {
     asgName: string;
 }
 
+export interface AutoScalingGroupCheckResponse extends AsgInput {
+    instanceIds: string[];
+}
+
 export interface OldestNodeResponse extends AsgInput {
     oldestElasticsearchNode: ElasticsearchNode;
 }

--- a/test/aws/autoscaling.test.ts
+++ b/test/aws/autoscaling.test.ts
@@ -1,5 +1,5 @@
 import {AutoScalingGroup, AutoScalingGroupsType} from 'aws-sdk/clients/autoscaling';
-import {singleASG} from "../../src/autoScalingGroupCheck";
+import {singleASG} from "../../src/aws/autoscaling";
 
 function asg(name: string, desiredCapacity: number): AutoScalingGroup {
     return {

--- a/test/aws/autoscaling.test.ts
+++ b/test/aws/autoscaling.test.ts
@@ -1,5 +1,5 @@
-import {getDesiredCapacity} from '../../src/aws/autoscaling'
 import {AutoScalingGroup, AutoScalingGroupsType} from 'aws-sdk/clients/autoscaling';
+import {singleASG} from "../../src/autoScalingGroupCheck";
 
 function asg(name: string, desiredCapacity: number): AutoScalingGroup {
     return {
@@ -14,30 +14,30 @@ function asg(name: string, desiredCapacity: number): AutoScalingGroup {
     };
 }
 
-describe("getDesiredCapacity", () => {
+describe("singleASG", () => {
+    it("should throw an error if more than one ASG is returned", () => {
+        const multipleASGs: AutoScalingGroupsType = {
+            AutoScalingGroups: [asg("asg1", 3), asg("asg2", 4)]
+        };
+        expect(() => { singleASG(multipleASGs.AutoScalingGroups) }).toThrow()
+    });
+});
+
+describe("singleASG", () => {
     it("should throw an error if no ASG information is returned", () => {
         const mock: AutoScalingGroupsType = {
             AutoScalingGroups: []
         };
-        expect(() => { getDesiredCapacity(mock); }).toThrow()
+        expect(() => { singleASG(mock.AutoScalingGroups) }).toThrow()
     });
 });
 
-describe("getDesiredCapacity", () => {
-    it("should throw an error if information is returned about more than one ASG", () => {
-        const mock: AutoScalingGroupsType = {
-            AutoScalingGroups: [asg("asg123", 3), asg("asg124", 4)]
-        }
-        expect(() => { getDesiredCapacity(mock); }).toThrow()
-    });
-});
-
-describe("getDesiredCapacity", () => {
+describe("DesiredCapacity", () => {
     it("should return the desired capacity correctly if we get info about a single ASG", () => {
         const desiredCapacity = 3;
         const mock: AutoScalingGroupsType = {
             AutoScalingGroups: [asg("asg123", desiredCapacity)]
         }
-        expect(getDesiredCapacity(mock)).toEqual(desiredCapacity);
+        expect(singleASG(mock.AutoScalingGroups).DesiredCapacity).toEqual(desiredCapacity);
     });
 });


### PR DESCRIPTION
Here we introduce an initial step which checks that ASG MaxSize is greater than Desired Capacity to allow for ReattachOldInstance step to complete, meaning clusters are not left with an extra node after the failed completion. This is in response to issue  #51 

I've  moved all checks which use the retrieved instance information to the new autoScalingGroupCheck to avoid extra calls to AWS. The totalRunningExecutions is also now in the new step, since this is the new first step.

cc @AWare I've tried to follow  your advice for managing async failure, but I'm not sure I've done this properly. If you get a minute to take a look I'd be grateful.

TODO: 
- [ ] Run this to check it works