### PR TITLE
Add support for multiple clusters per account

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -352,7 +352,7 @@ Resources:
     - RemoveNodeLambda
     Properties:
       StateMachineName:
-        !Sub ${Stack}-Elasticsearch-Node-Rotation
+        !Sub ${Stack}-Elasticsearch-Node-Rotation-${Stage}
       DefinitionString:
         !Sub
           - |
@@ -451,7 +451,7 @@ Resources:
   DataNodeRotationSchedule:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub ${Stack}-data-node-rotation-schedule
+      Name: !Sub ${Stack}-data-node-rotation-schedule-${Stage}
       ScheduleExpression: !Ref DataNodeRotationCronExpression
       State: ENABLED
       Targets:
@@ -474,7 +474,7 @@ Resources:
     Condition: HasWarmDataNodes
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub ${Stack}-warm-data-node-rotation-schedule
+      Name: !Sub ${Stack}-warm-data-node-rotation-schedule-${Stage}
       ScheduleExpression: !Ref WarmDataNodeRotationCronExpression
       State: ENABLED
       Targets:
@@ -497,7 +497,7 @@ Resources:
     Condition: HasDedicatedMasters
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub ${Stack}-master-node-rotation-schedule
+      Name: !Sub ${Stack}-master-node-rotation-schedule-${Stage}
       ScheduleExpression: !Ref MasterNodeRotationCronExpression
       State: ENABLED
       Targets:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: Stage name.
   Stack:
     Type: String
-    Description: The name of the stack. This field is optional, use only if you need to run multiple instances of node rotation.
+    Description: The name of the stack, for context in alerts and/or running node rotation against multiple clusters.
   DeployS3Bucket:
     Type: String
     Description: Bucket which contains .zip file used by lambda functions e.g. deploy-tools-dist.
@@ -39,21 +39,17 @@ Parameters:
   SNSTopicForAlerts:
     Type: String
     Description: The name of the SNS topic used for alerting in the case of a failed rotation attempt.
-  ClusterName:
-    Type: String
-    Description: The name of the elasticsearch cluster, for context in alerts.
 
 Conditions:
   HasDedicatedMasters: !Not [!Equals [!Ref DedicatedMasterAsg, '']]
   HasWarmDataNodes: !Not [!Equals [!Ref WarmDataNodeAsg, '']]
-  HasStackName: !Not [!Equals [!Ref Stack, '']]
 
 Resources:
 
   NodeRotationLambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${ClusterName}-NodeRotation-${Stage}
+      RoleName: !Sub ${Stack}-NodeRotation-${Stage}
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
@@ -184,10 +180,7 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName: !If
-        - HasStackName
-        - !Sub ${Stack}-enr-cluster-status-check-${Stage}
-        - !Sub enr-cluster-status-check-${Stage}
+      FunctionName: !Sub ${Stack}-enr-cluster-status-check-${Stage}
       Description: "Checks the status of an Elasticsearch cluster"
       Handler: "clusterStatusCheck.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -205,10 +198,7 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName: !If
-        - HasStackName
-        - !Sub ${Stack}-enr-auto-scaling-group-check-${Stage}
-        - !Sub enr-auto-scaling-group-check-${Stage}
+      FunctionName: !Sub ${Stack}-enr-auto-scaling-group-check-${Stage}
       Description: "Checks that a single Auto Scaling Group is returned with a maximum limit greater than the desired capacity"
       Handler: "autoScalingGroupCheck.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -226,10 +216,7 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName: !If
-        - HasStackName
-        - !Sub ${Stack}-enr-get-oldest-node-${Stage}
-        - !Sub enr-get-oldest-node-${Stage}
+      FunctionName: !Sub ${Stack}-enr-get-oldest-node-${Stage}
       Description: "Finds the oldest node in an Elasticsearch cluster"
       Handler: "getOldestNode.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -247,10 +234,7 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName: !If
-        - HasStackName
-        - !Sub ${Stack}-enr-add-node-${Stage}
-        - !Sub enr-add-node-${Stage}
+      FunctionName: !Sub ${Stack}-enr-add-node-${Stage}
       Description: "Disables re-balancing before adding a new node into the Elasticsearch cluster"
       Handler: "addNode.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -268,10 +252,7 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName: !If
-      - HasStackName
-      - !Sub ${Stack}-enr-cluster-size-check-${Stage}
-      - !Sub enr-cluster-size-check-${Stage}
+      FunctionName: !Sub ${Stack}-enr-cluster-size-check-${Stage}
       Description: "Confirms that the Elasticsearch cluster is the expected size"
       Handler: "clusterSizeCheck.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -289,10 +270,7 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName: !If
-      - HasStackName
-      - !Sub ${Stack}-enr-reattach-old-instance-${Stage}
-      - !Sub enr-reattach-old-instance-${Stage}
+      FunctionName: !Sub ${Stack}-enr-reattach-old-instance-${Stage}
       Description: "Reattaches old instance to the ASG"
       Handler: "reattachOldInstance.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -310,10 +288,7 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName: !If
-      - HasStackName
-      - !Sub ${Stack}-enr-migrate-shards-${Stage}
-      - !Sub enr-migrate-shards-${Stage}
+      FunctionName: !Sub ${Stack}-enr-migrate-shards-${Stage}
       Description: "Migrates shards between two nodes"
       Handler: "migrateShards.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -331,10 +306,7 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName: !If
-      - HasStackName
-      - !Sub ${Stack}-enr-shard-migration-check-${Stage}
-      - !Sub enr-shard-migration-check-${Stage}
+      FunctionName: !Sub ${Stack}-enr-shard-migration-check-${Stage}
       Description: "Confirms that all shards have been migrated (and that cluster is green) or exits with an error"
       Handler: "shardMigrationCheck.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -352,10 +324,7 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName: !If
-        - HasStackName
-        - !Sub ${Stack}-enr-remove-node-${Stage}
-        - !Sub enr-remove-node-${Stage}
+      FunctionName: !Sub ${Stack}-enr-remove-node-${Stage}
       Description: "Removes the oldest node in the cluster (and terminates the instance) before re-enabling re-balancing"
       Handler: "removeNode.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -383,7 +352,7 @@ Resources:
     - RemoveNodeLambda
     Properties:
       StateMachineName:
-        !Sub Elasticsearch-Node-Rotation-${ClusterName}
+        !Sub ${Stack}-Elasticsearch-Node-Rotation
       DefinitionString:
         !Sub
           - |
@@ -482,7 +451,7 @@ Resources:
   DataNodeRotationSchedule:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub data-node-rotation-schedule-${ClusterName}
+      Name: !Sub ${Stack}-data-node-rotation-schedule
       ScheduleExpression: !Ref DataNodeRotationCronExpression
       State: ENABLED
       Targets:
@@ -505,7 +474,7 @@ Resources:
     Condition: HasWarmDataNodes
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub warm-data-node-rotation-schedule-${ClusterName}
+      Name: !Sub ${Stack}-warm-data-node-rotation-schedule
       ScheduleExpression: !Ref WarmDataNodeRotationCronExpression
       State: ENABLED
       Targets:
@@ -528,7 +497,7 @@ Resources:
     Condition: HasDedicatedMasters
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub master-node-rotation-schedule-${ClusterName}
+      Name: !Sub ${Stack}-master-node-rotation-schedule
       ScheduleExpression: !Ref MasterNodeRotationCronExpression
       State: ENABLED
       Targets:
@@ -552,7 +521,7 @@ Resources:
     Properties:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicForAlerts}
-      AlarmName: !Sub Failed to complete node rotation for ${ClusterName}, ${Stage} Elasticsearch Cluster
+      AlarmName: !Sub Failed to complete node rotation for ${Stack}, ${Stage} Elasticsearch Cluster
       AlarmDescription: !Sub
         - Elasticsearch Node Rotation failed - please see Step Function execution history for ${StepFunctionName}
         - { StepFunctionName: !GetAtt NodeRotationStepFunction.Name }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -6,6 +6,9 @@ Parameters:
   Stage:
     Type: String
     Description: Stage name.
+  Stack:
+    Type: String
+    Description: The name of the stack. This field is optional, use only if you need to run multiple instances of node rotation.
   DeployS3Bucket:
     Type: String
     Description: Bucket which contains .zip file used by lambda functions e.g. deploy-tools-dist.
@@ -43,6 +46,7 @@ Parameters:
 Conditions:
   HasDedicatedMasters: !Not [!Equals [!Ref DedicatedMasterAsg, '']]
   HasWarmDataNodes: !Not [!Equals [!Ref WarmDataNodeAsg, '']]
+  HasStackName: !Not [!Equals [!Ref Stack, '']]
 
 Resources:
 
@@ -180,8 +184,10 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName:
-          !Sub enr-cluster-status-check-${Stage}
+      FunctionName: !If
+        - HasStackName
+        - !Sub ${Stack}-enr-cluster-status-check-${Stage}
+        - !Sub enr-cluster-status-check-${Stage}
       Description: "Checks the status of an Elasticsearch cluster"
       Handler: "clusterStatusCheck.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -199,8 +205,10 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName:
-        !Sub enr-auto-scaling-group-check-${Stage}
+      FunctionName: !If
+        - HasStackName
+        - !Sub ${Stack}-enr-auto-scaling-group-check-${Stage}
+        - !Sub enr-auto-scaling-group-check-${Stage}
       Description: "Checks that a single Auto Scaling Group is returned with a maximum limit greater than the desired capacity"
       Handler: "autoScalingGroupCheck.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -218,8 +226,10 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName:
-          !Sub enr-get-oldest-node-${Stage}
+      FunctionName: !If
+        - HasStackName
+        - !Sub ${Stack}-enr-get-oldest-node-${Stage}
+        - !Sub enr-get-oldest-node-${Stage}
       Description: "Finds the oldest node in an Elasticsearch cluster"
       Handler: "getOldestNode.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -237,8 +247,10 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName:
-          !Sub enr-add-node-${Stage}
+      FunctionName: !If
+        - HasStackName
+        - !Sub ${Stack}-enr-add-node-${Stage}
+        - !Sub enr-add-node-${Stage}
       Description: "Disables re-balancing before adding a new node into the Elasticsearch cluster"
       Handler: "addNode.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -256,8 +268,10 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName:
-          !Sub enr-cluster-size-check-${Stage}
+      FunctionName: !If
+      - HasStackName
+      - !Sub ${Stack}-enr-cluster-size-check-${Stage}
+      - !Sub enr-cluster-size-check-${Stage}
       Description: "Confirms that the Elasticsearch cluster is the expected size"
       Handler: "clusterSizeCheck.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -275,8 +289,10 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName:
-        !Sub enr-reattach-old-instance-${Stage}
+      FunctionName: !If
+      - HasStackName
+      - !Sub ${Stack}-enr-reattach-old-instance-${Stage}
+      - !Sub enr-reattach-old-instance-${Stage}
       Description: "Reattaches old instance to the ASG"
       Handler: "reattachOldInstance.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -294,8 +310,10 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName:
-          !Sub enr-migrate-shards-${Stage}
+      FunctionName: !If
+      - HasStackName
+      - !Sub ${Stack}-enr-migrate-shards-${Stage}
+      - !Sub enr-migrate-shards-${Stage}
       Description: "Migrates shards between two nodes"
       Handler: "migrateShards.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -313,8 +331,10 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName:
-          !Sub enr-shard-migration-check-${Stage}
+      FunctionName: !If
+      - HasStackName
+      - !Sub ${Stack}-enr-shard-migration-check-${Stage}
+      - !Sub enr-shard-migration-check-${Stage}
       Description: "Confirms that all shards have been migrated (and that cluster is green) or exits with an error"
       Handler: "shardMigrationCheck.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -332,8 +352,10 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: NodeRotationLambdaRole
     Properties:
-      FunctionName:
-          !Sub enr-remove-node-${Stage}
+      FunctionName: !If
+        - HasStackName
+        - !Sub ${Stack}-enr-remove-node-${Stage}
+        - !Sub enr-remove-node-${Stage}
       Description: "Removes the oldest node in the cluster (and terminates the instance) before re-enabling re-balancing"
       Handler: "removeNode.handler"
       Role: !GetAtt [ NodeRotationLambdaRole, Arn ]
@@ -530,7 +552,7 @@ Resources:
     Properties:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicForAlerts}
-      AlarmName: !Sub Failed to complete node rotation for ${Stage} Elasticsearch Cluster
+      AlarmName: !Sub Failed to complete node rotation for ${ClusterName}, ${Stage} Elasticsearch Cluster
       AlarmDescription: !Sub
         - Elasticsearch Node Rotation failed - please see Step Function execution history for ${StepFunctionName}
         - { StepFunctionName: !GetAtt NodeRotationStepFunction.Name }

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -10,18 +10,17 @@ templates:
     type: aws-lambda
     contentDirectory: elasticsearch-node-rotation
     parameters:
-      prefixStack: false
       fileName: elasticsearch-node-rotation.zip
       functionNames:
-      - enr-auto-scaling-group-check-
-      - enr-cluster-status-check-
-      - enr-get-oldest-node-
-      - enr-add-node-
-      - enr-cluster-size-check-
-      - enr-reattach-old-instance-
-      - enr-migrate-shards-
-      - enr-shard-migration-check-
-      - enr-remove-node-
+      - -enr-auto-scaling-group-check-
+      - -enr-cluster-status-check-
+      - -enr-get-oldest-node-
+      - -enr-add-node-
+      - -enr-cluster-size-check-
+      - -enr-reattach-old-instance-
+      - -enr-migrate-shards-
+      - -enr-shard-migration-check-
+      - -enr-remove-node-
 
 deployments:
   deploy-tools-enr-cloudformation:


### PR DESCRIPTION
## What does this change?
This creates resources with an optional "Stack" parameter appended to the resource names, in order to support our use case on Investigations where we want to rotate the nodes of both a prod and code cluster.

Prior to this change, we were unable to create a second step function, since the function names already existed from our first stack.

## How to test
We have tested that we can create two node rotation step functions in our account with this change, and have tested that the step function fully executes. We have also checked there is no diff when you attempt to update a stack with this new template to an account with this stack already defined (not supplying a value for "Stack").

To verify independently, update existing cloudformation with this template.