### PR TITLE
Allow master-eligible nodes to be removed even if shards are relocating

### DIFF
--- a/src/shardMigrationCheck.ts
+++ b/src/shardMigrationCheck.ts
@@ -7,12 +7,10 @@ export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNo
         getDocuments(event.oldestElasticsearchNode)
     ]).then(([clusterStatus, documents]) => {
         const hasDocuments = documents.count > 0;
-        const isMasterAndShardsRelocating = event.oldestElasticsearchNode.isMasterEligible && clusterStatus.relocating_shards > 0;
         const clusterIsUnhealthy = !(clusterStatus.status === "green");
 
-        if (clusterIsUnhealthy || hasDocuments || isMasterAndShardsRelocating) {
-            const error =
-                `Check failed: hasDocuments=${hasDocuments} isMasterAndShardsRelocating=${isMasterAndShardsRelocating} clusterIsUnhealthy=${clusterIsUnhealthy}`;
+        if (clusterIsUnhealthy || hasDocuments) {
+            const error = `Check failed: hasDocuments=${hasDocuments} clusterIsUnhealthy=${clusterIsUnhealthy}`;
             console.log(error);
             throw new Error(error);
         } else return event;


### PR DESCRIPTION
## What does this change?

We believe that the final checks which run before a node is removed are too strict and this is causing problems for the Ophan team (see https://github.com/guardian/elasticsearch-node-rotation/issues/60 for more details).

This PR removes the problematic check, which applies to master-eligible nodes only, as we believe that it's superfluous.

## How to test

We've tested this change by [deploying to the `deployTools` account (only)](https://riffraff.gutools.co.uk/deployment/view/2f3c6e97-cadd-4f86-b871-3a25c86d0a8e) and rotating:

a) a data note
b) the master node (whilst shard relocation was in progress)

## How can we measure success?

The Ophan team should experience fewer failures. Clusters affected by this change should remain stable.

## Have we considered potential risks?

Yes, see `How to test` section.