### PR TITLE
Missing data for the executions failed alarm is OK

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -535,4 +535,5 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       Statistic: Sum
+      TreatMissingData: notBreaching
     DependsOn: NodeRotationStepFunction


### PR DESCRIPTION
Small tweak to the Cloudwatch alarm for node rotation. At the moment it sits in `INSUFFICIENT_DATA` when no failures have occurred, which is fine but confused me a bit. After this PR it sits in `OK`.