### PR TITLE
Use node version specified in .nvmrc for CI

### DIFF
--- a/teamcity.sh
+++ b/teamcity.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -e
 
+# source NVM on teamcity
+if [ -e "${NVM_DIR}/nvm.sh" ]; then
+    . ${NVM_DIR}/nvm.sh
+else
+    . $(brew --prefix nvm)/nvm.sh
+fi
+nvm install
+nvm use
+
 npm install -g yarn
 
 yarn install


### PR DESCRIPTION
## What does this change?

The version of node being used in CI was out of sync with the version specified in [`.nvmrc`](https://github.com/guardian/elasticsearch-node-rotation/blob/ea9bd7e533720e5e75f8a62efb6b19783d30fb9d/.nvmrc#L1) and [CloudFormation](https://github.com/guardian/elasticsearch-node-rotation/blob/ea9bd7e533720e5e75f8a62efb6b19783d30fb9d/cloudformation.yaml#L191):

![image](https://user-images.githubusercontent.com/19384074/115027396-92914900-9ebb-11eb-99c6-9d93d2320396.png)

_N.B. this build step was disabled for the purposes of testing this PR which means that nothing else will currently build until this is merged 🙈 - this is another good reason to move all CI setup into version control!_

The [build log](https://teamcity.gutools.co.uk/buildConfiguration/Tools_ElasticsearchNodeRotation/641931?buildTab=log&focusLine=3&linesState=382) shows that this change is working as expected:
`Now using node v10.17.0 (npm v6.11.3)`