### PR TITLE
Restrict SSM run command by Stack and Stage

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -5,10 +5,10 @@ Description: "Step Function for rotating Elasticsearch nodes"
 Parameters:
   Stage:
     Type: String
-    Description: Stage name.
+    Description: Stage tag, to restrict SSM commands to just the required instances and for context in alerts.
   Stack:
     Type: String
-    Description: The name of the stack, for context in alerts and/or running node rotation against multiple clusters.
+    Description: Stack tag, to restrict SSM commands to just the required instances and for context in alerts.
   DeployS3Bucket:
     Type: String
     Description: Bucket which contains .zip file used by lambda functions e.g. deploy-tools-dist.
@@ -111,10 +111,19 @@ Resources:
           PolicyDocument:
             Statement:
               - Effect: Allow
-                Action:
-                - ssm:SendCommand
-                - ssm:GetCommandInvocation
+                Action: ssm:GetCommandInvocation
+                # This cannot be restricted further but that's OK, it's just reading the output of commands
                 Resource: "*"
+              - Effect: Allow
+                Action: ssm:SendCommand
+                Resource: !Sub arn:aws:ssm:${AWS::Region}::document/AWS-RunShellScript
+              - Effect: Allow
+                Action: ssm:SendCommand
+                Resource: !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
+                Condition:
+                  StringEquals:
+                    ssm:resourceTag/Stack: !Ref Stack
+                    ssm:resourceTag/Stage: !Ref Stage
         - PolicyName: SsmS3Policy
           PolicyDocument:
             Statement:


### PR DESCRIPTION
At the moment the role can run any arbitrary commands on any instance in the account. It's not that big a deal since the role is only used within a lambda that is not publically accessible but if something were to exfiltrate those credentials it's totally game over for the entire account.

The tighest way of doing this would be to have a separate SSM document for each command permissioned accordingly, rather than allowing RunShellScript. That's quite heavyweight though and would be annoying for future developers trying to make small changes to each command.

Ideally we'd restrict even further by aws:autoscaling:groupName tied to the master, warm and hot autoscaling groups. That doesn't work unfortunately as the instance loses that tag once it is detached. In https://github.com/guardian/investigations-platform/pull/364 we use aws:cloudformation:stack-name but as ENR is a generic tool that already has Stack and Stage passed in, I decided to go with those for now. I haven't further restricted by App as we have various values for those across our many Elasticsearch clusters. It would be nice to use stack name or add App though, as even unrestricted shell access on a given Stack, Stage combo isn't great.

I'd be interested in thoughts about where best to strike the balance here?