### PR TITLE
tighten tag based discovery and make this the owner of the ssm output bucket

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: "Step Function for rotating Elasticsearch nodes"
+Description: "Step Function for rotating ElasticSearch nodes (regardless of their Stage, i.e. the PROD instance of this stack will rotate oldest ES instances belonging to any Stage, assuming the instances have the `RotateWithElasticsearchNodeRotation` tag set to true)"
 
 Parameters:
   Stack:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: "Step Function for rotating ElasticSearch nodes (regardless of their Stage, i.e. the PROD instance of this stack will rotate oldest ES instances belonging to any Stage, assuming the instances have the `RotateWithElasticsearchNodeRotation` tag set to true)"
+Description: "Step Function for rotating ElasticSearch nodes (regardless of their Stage, i.e. the INFRA/PROD instance of this stack will rotate oldest ES instances belonging to any Stage, assuming the instances have the `RotateWithElasticsearchNodeRotation` tag set to true)"
 
 Parameters:
   Stack:
@@ -13,7 +13,7 @@ Parameters:
   Stage:
     Type: String
     Description: Stage name for Riff-Raff deploys to support per-account continuous deployment of this project
-    Default: PROD
+    Default: INFRA
   DeployS3Bucket:
     Type: String
     Description: Bucket which contains .zip file used by lambda functions e.g. deploy-tools-dist.
@@ -29,13 +29,43 @@ Parameters:
     Default: 7
   SsmOutputBucketName:
     Type: String
-    Description: Bucket used to store SSM command output. This bucket must already exist and the instances which receive SSM commands must have PutObject permissions for this bucket.
+    Description: OPTIONAL! Bucket used to store SSM command output. The instances which receive SSM commands must have PutObject permissions for this bucket. If this is not provided a bucket will be created as part of this stack.
+    Default: ""
   SNSTopicForAlerts:
     Type: String
     Description: The name of the SNS topic used for alerting in the case of a failed rotation attempt.
 
 
+Conditions:
+  ShouldCreateSsmOutputBucket: !Equals
+    - !Ref SsmOutputBucketName
+    - ""
+
 Resources:
+
+  NodeRotationSsmOutputBucket:
+    Type: AWS::S3::Bucket
+    Condition: ShouldCreateSsmOutputBucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: true
+        RestrictPublicBuckets: true
+      Tags:
+        - { Key: Stack, Value: !Ref Stack }
+        - { Key: Stage, Value: !Ref Stage }
+
+  NodeRotationBucketSsmParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: "/account/services/node-rotation-ssm-output-bucket-name"
+      Type: String
+      Value: !If [ShouldCreateSsmOutputBucket, !Ref NodeRotationSsmOutputBucket, !Ref SsmOutputBucketName]
 
   NodeRotationLambdaRole:
     Type: AWS::IAM::Role
@@ -101,11 +131,11 @@ Resources:
               - Effect: Allow
                 Action: s3:ListBucket
                 Resource:
-                - !Sub arn:aws:s3:::${SsmOutputBucketName}
+                - !Sub arn:aws:s3:::${NodeRotationBucketSsmParameter.Value}
               - Effect: Allow
                 Action: s3:GetObject
                 Resource:
-                - !Sub arn:aws:s3:::${SsmOutputBucketName}/*
+                - !Sub arn:aws:s3:::${NodeRotationBucketSsmParameter.Value}/*
         - PolicyName: QueryStepFunctionHistory
           PolicyDocument:
             Statement:
@@ -172,7 +202,7 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+          SSM_BUCKET_NAME: !GetAtt NodeRotationBucketSsmParameter.Value
 
   ClusterStatusCheckLambda:
     Type: "AWS::Lambda::Function"
@@ -190,7 +220,7 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+          SSM_BUCKET_NAME: !GetAtt NodeRotationBucketSsmParameter.Value
 
   AutoScalingGroupCheckLambda:
     Type: "AWS::Lambda::Function"
@@ -208,7 +238,7 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+          SSM_BUCKET_NAME: !GetAtt NodeRotationBucketSsmParameter.Value
 
   GetOldestNodeLambda:
     Type: "AWS::Lambda::Function"
@@ -226,7 +256,7 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+          SSM_BUCKET_NAME: !GetAtt NodeRotationBucketSsmParameter.Value
 
   AddNodeLambda:
     Type: "AWS::Lambda::Function"
@@ -244,7 +274,7 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+          SSM_BUCKET_NAME: !GetAtt NodeRotationBucketSsmParameter.Value
 
   ClusterSizeCheckLambda:
     Type: "AWS::Lambda::Function"
@@ -262,7 +292,7 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+          SSM_BUCKET_NAME: !GetAtt NodeRotationBucketSsmParameter.Value
 
   ReattachOldInstanceLambda:
     Type: "AWS::Lambda::Function"
@@ -280,7 +310,7 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+          SSM_BUCKET_NAME: !GetAtt NodeRotationBucketSsmParameter.Value
 
   MigrateShardsLambda:
     Type: "AWS::Lambda::Function"
@@ -298,7 +328,7 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+          SSM_BUCKET_NAME: !GetAtt NodeRotationBucketSsmParameter.Value
 
   ShardMigrationCheckLambda:
     Type: "AWS::Lambda::Function"
@@ -316,7 +346,7 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+          SSM_BUCKET_NAME: !GetAtt NodeRotationBucketSsmParameter.Value
 
   RemoveNodeLambda:
     Type: "AWS::Lambda::Function"
@@ -334,7 +364,7 @@ Resources:
       Timeout: 300
       Environment:
         Variables:
-          SSM_BUCKET_NAME: !Ref SsmOutputBucketName
+          SSM_BUCKET_NAME: !GetAtt NodeRotationBucketSsmParameter.Value
 
   NodeRotationStepFunction:
     Type: "AWS::StepFunctions::StateMachine"

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -56,6 +56,14 @@ Resources:
         IgnorePublicAcls: true
         BlockPublicPolicy: true
         RestrictPublicBuckets: true
+      LifecycleConfiguration:
+        Rules:
+          - Id: RetentionRule
+            Status: Enabled
+            Transitions:
+              - TransitionInDays: 1
+                StorageClass: GLACIER
+            ExpirationInDays: 14
       Tags:
         - { Key: Stack, Value: !Ref Stack }
         - { Key: Stage, Value: !Ref Stage }

--- a/src/aws/ec2Instances.ts
+++ b/src/aws/ec2Instances.ts
@@ -38,7 +38,7 @@ export function getSpecificInstance(instanceIds: string[], instanceFilter: Insta
     )
 }
 
-export async function getInstancesByTag(tagKey: string): Promise<Instance[]> {
+export async function getInstancesByTag(tagKey: string, tagValue?: string): Promise<Instance[]> {
     console.log(`Finding EC2 instances that have tag ${tagKey}`);
 
     async function _getInstancesByTag(acc: Instance[] = [], nextToken?: string): Promise<Instance[]> {
@@ -46,12 +46,12 @@ export async function getInstancesByTag(tagKey: string): Promise<Instance[]> {
             MaxResults: 1000,
             NextToken: nextToken,
             Filters: [
-                { "Name": "tag-key", Values: [tagKey] }
+                { "Name": `tag${tagValue ? `:${tagKey}` : "-key"}`, Values: [tagValue || tagKey] }
             ]
         };
 
         const response = await awsEc2.describeInstances(params).promise();
-        
+
         const instances = buildInstances(response);
         const allInstances = acc.concat(instances);
 

--- a/src/discoverAutoScalingGroup.ts
+++ b/src/discoverAutoScalingGroup.ts
@@ -18,8 +18,8 @@ export async function handler(event: StateMachineInput): Promise<AsgDiscoveryRes
         return { asgName: event.asgName, skipRotation: false };
     }
 
-    const instances = await getInstancesByTag(event.autoScalingGroupDiscoveryTagKey);
-    
+    const instances = await getInstancesByTag(event.autoScalingGroupDiscoveryTagKey, "true");
+
     console.log(`Found ${instances.length} instances with tag ${event.autoScalingGroupDiscoveryTagKey}`);
     instances.forEach(instance => {
         console.log(`${instance.id} (${instance.autoScalingGroupName}) launched at ${instance.launchTime.toISOString()}}`);


### PR DESCRIPTION
Following https://github.com/guardian/elasticsearch-node-rotation/pull/68 the process (specifically the `DiscoverAutoScalingGroupLambda`) was picking up instances, regardless of their **Stage**, e.g. the PROD rotation process was picking up TEST/CODE instances as well as PROD ones, which then failed on a subsequent step because the TEST/CODE instances did not have S3 permissions to write SSM command stdout/stderr to the S3 bucket belonging to PROD.

## What does this change?
This PR makes that clear in the description of the CFN stack to avoid confusion.

Whilst there I also made it such that the when finding ASGs/instances by the `RotateWithElasticsearchNodeRotation` tag, it now makes sure that value is "true", so its more intuitive (as I found it was not when I set that tag value to "false" only to find they still got picked up by the lambda.

## How to test
Already tested in combination with https://github.com/guardian/editorial-tools-platform/pull/552
![image](https://user-images.githubusercontent.com/19289579/127209642-63b21666-d7cb-4b3a-9eb2-582cc0fba73b.png)
