### PR TITLE
Add extra information to shardMigrationCheck error

### DIFF
--- a/src/shardMigrationCheck.ts
+++ b/src/shardMigrationCheck.ts
@@ -10,7 +10,7 @@ export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNo
         const clusterIsUnhealthy = !(clusterStatus.status === "green");
 
         if (clusterIsUnhealthy || hasDocuments) {
-            const error = `Check failed: hasDocuments=${hasDocuments} clusterIsUnhealthy=${clusterIsUnhealthy}`;
+            const error = `Check failed: hasDocuments=${hasDocuments} (${event.oldestElasticsearchNode.ec2Instance.id} still has ${documents.count} docs) clusterIsUnhealthy=${clusterIsUnhealthy} (status is currently ${clusterStatus.status})`;
             console.log(error);
             throw new Error(error);
         } else return event;


### PR DESCRIPTION
## What does this change?
This logs a few extra variables in`shardMigrationCheck`'s error message, namely
* instance id
* number of docs in the node
* cluster health

When the shard migration check times out, I think it'd be useful to have these bits of data listed to understand how far along the migration was at, and also convenient data points when recovering from the step function failure.

The intention is for the message to look like

```
Check failed: hasDocuments=true(i-123 still has 1000 docs) clusterIsUnhealthy=false (status is currently green)
```

![Step_Functions_Management_Console](https://user-images.githubusercontent.com/1672034/128741556-2d16239c-2c84-4171-b7b9-8796e4172beb.png)


## How to test
Good question! I'm not familiar with this aspect of the project, don't know if there's a way to test it pre deploying.

## Have we considered potential risks?
If this code is wrong, the lambda will _always_ fail I reckon. So the step function will always fail.
