### PR TITLE
Retry shard migration check for longer (5 hours)

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -481,7 +481,7 @@ Resources:
                   "Retry": [ {
                     "ErrorEquals": [ "States.ALL" ],
                     "IntervalSeconds": 120,
-                    "MaxAttempts": 120,
+                    "MaxAttempts": 180,
                     "BackoffRate": 1.0
                   } ]
                 },

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -481,7 +481,7 @@ Resources:
                   "Retry": [ {
                     "ErrorEquals": [ "States.ALL" ],
                     "IntervalSeconds": 120,
-                    "MaxAttempts": 180,
+                    "MaxAttempts": 150,
                     "BackoffRate": 1.0
                   } ]
                 },


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This increases the max retries of the `shard migration check` step of the step function to 150. That means that with the current interval of 120 seconds we will retry in total for 5 hours.  I'm doing this because we've had a few failures for central ELK recently which would've been successful if the retries had continued for a bit longer.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
The risk of changing this value seems low, so I suggest we test by releasing.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Decrease in instances where the step function times out before completing the reallocation of data.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
~I considered that increasing this value too far would mean that the step function could fail outside of working hours more regularly. Perhaps this is valid, as it's currently ending at 3pm and this change would take it to 5pm.~ Changed to 5 hours instead of 6 now.