### PR TITLE
Only consider rotating ASGs with running instances

### DIFF
--- a/src/aws/ec2Instances.ts
+++ b/src/aws/ec2Instances.ts
@@ -46,6 +46,7 @@ export async function getInstancesByTag(tagKey: string, tagValue?: string): Prom
             MaxResults: 1000,
             NextToken: nextToken,
             Filters: [
+                { "Name": "instance-state-name", Values: ["running"] },
                 { "Name": `tag${tagValue ? `:${tagKey}` : "-key"}`, Values: [tagValue || tagKey] }
             ]
         };


### PR DESCRIPTION
We are currently running two ES clusters and noticed that when we took one down, that node rotation wasn't filtering to just consider running instances when finding potential instances to rotate, so it attempted to rotate an ASG that only had terminated instances.

We could see in this execution of the step function after we took down our elasticsearch-7 cluster that the elasticsearch-7 ASG had been picked for node rotation
![image](https://user-images.githubusercontent.com/3072877/134385474-94142347-b09f-4a98-bc0d-ffd7fb05f0e5.png)

So we went to look in the logs corresponding to the DiscoverAutoScalingGroup step and could see that many instances in elasticsearch-7 ASGs were still being picked up 
![image](https://user-images.githubusercontent.com/3072877/134385706-b6b59b95-d04c-451e-a637-80e588ead4ae.png)

... even though those instances were all recently terminated 
![image](https://user-images.githubusercontent.com/3072877/134386005-a0d7108e-5ebb-483c-9a19-847317bf8a02.png)
