### PR TITLE
Retry Elasticsearch commands

### DIFF
--- a/src/addNode.ts
+++ b/src/addNode.ts
@@ -1,6 +1,6 @@
 import {detachInstance} from './aws/autoscaling';
 import {AddNodeResponse, ClusterStatusResponse} from './utils/handlerInputs';
-import {getClusterHealth, updateRebalancingStatus} from './elasticsearch/elasticsearch';
+import {Elasticsearch} from './elasticsearch/elasticsearch';
 import {Instance} from './aws/types';
 import {ElasticsearchClusterStatus} from './elasticsearch/types';
 
@@ -8,11 +8,13 @@ export async function handler(event: ClusterStatusResponse): Promise<AddNodeResp
 
     const oldestInstance: Instance = event.oldestElasticsearchNode.ec2Instance;
     const asg: string = event.asgName;
+    const elasticsearchClient = new Elasticsearch(oldestInstance.id)
 
     return new Promise<AddNodeResponse>((resolve, reject) => {
-        updateRebalancingStatus(oldestInstance.id, "none")
+
+        elasticsearchClient.updateRebalancingStatus("none")
             .then(() => detachInstance(oldestInstance, asg))
-            .then(() => getClusterHealth(oldestInstance.id))
+            .then(() => elasticsearchClient.getClusterHealth())
             .then((clusterStatus: ElasticsearchClusterStatus) => {
                 const response: AddNodeResponse = {
                     "asgName": asg,

--- a/src/clusterStatusCheck.ts
+++ b/src/clusterStatusCheck.ts
@@ -1,9 +1,11 @@
 import {ClusterStatusResponse, OldestNodeResponse} from './utils/handlerInputs';
-import {getClusterHealth} from './elasticsearch/elasticsearch';
+import {Elasticsearch} from './elasticsearch/elasticsearch';
 
 export async function handler(event: OldestNodeResponse): Promise<ClusterStatusResponse> {
+    const elasticsearchClient = new Elasticsearch(event.oldestElasticsearchNode.ec2Instance.id)
+
     try {
-        const clusterStatus = await getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id)
+        const clusterStatus = await elasticsearchClient.getClusterHealth()
 
         return ({
             "asgName": event.asgName,

--- a/src/elasticsearch/elasticsearch.ts
+++ b/src/elasticsearch/elasticsearch.ts
@@ -1,25 +1,40 @@
 import {Instance} from '../aws/types';
-import {
-    Documents,
-    ElasticsearchClusterStatus,
-    ElasticsearchNode,
-    NodeStats,
-} from './types';
+import {Documents, ElasticsearchClusterStatus, ElasticsearchNode, NodeStats,} from './types';
 import {ssmCommand} from '../utils/ssmCommand';
+import {retry} from '../utils/helperFunctions';
 
-export function getClusterHealth(instanceId: string): Promise<ElasticsearchClusterStatus> {
-    return ssmCommand('curl localhost:9200/_cluster/health', instanceId)
-        .then((result: string) => {
-            const clusterStatus: ElasticsearchClusterStatus = JSON.parse(result);
-            return clusterStatus;
-        })
-}
+export class Elasticsearch {
+    instanceId: string;
 
-export function getElasticsearchNode(instance: Instance): Promise<ElasticsearchNode> {
-    console.log(`Searching for Elasticsearch node with private ip: ${instance.privateIp}`);
-    return ssmCommand(`curl localhost:9200/_nodes/${instance.privateIp}`, instance.id)
-        .then((result: string) => {
-            const json = JSON.parse(result);
+    constructor(instanceId: string) {
+        this.instanceId = instanceId;
+    }
+
+    execute(commandPath: string, requestJson?: object): Promise<any> {
+        const requestJsonSettings = requestJson ? `-X PUT -H 'Content-Type: application/json' -d '${JSON.stringify(requestJson)}'` : "";
+        return ssmCommand(`curl localhost:9200${commandPath} ${requestJsonSettings}`, this.instanceId)
+            .then((result: string) => {
+                return JSON.parse(result);
+            })
+    }
+
+    executeCommand(commandPath: string, requestJson: object, taskName: string): Promise<boolean> {
+        return retry(() => this.execute(commandPath, requestJson).then((jsonResult: any) => {
+            if (!(jsonResult.acknowledged === true)) {
+                throw `unexpected Elasticsearch response when attempting to ${taskName}, we got: ${jsonResult}`;
+            } else {
+                return true;
+            }
+        }), taskName, 5);
+    }
+
+    getClusterHealth(): Promise<ElasticsearchClusterStatus> {
+        return this.execute('/_cluster/health')
+    }
+
+    getElasticsearchNode(instance: Instance): Promise<ElasticsearchNode> {
+        console.log(`Searching for Elasticsearch node with private ip: ${instance.privateIp}`);
+        return this.execute(`/_nodes/${instance.privateIp}`).then((json: any) => {
             if (json._nodes.total === 1) {
                 const nodeId: string = Object.keys(json.nodes)[0];
                 const isMaster: boolean = json.nodes[nodeId].settings.node.master == 'true';
@@ -28,55 +43,25 @@ export function getElasticsearchNode(instance: Instance): Promise<ElasticsearchN
                 throw `expected information about a single node, but got: ${JSON.stringify(json)}`;
             }
         })
+    }
+
+    getDocuments(node: ElasticsearchNode): Promise<Documents> {
+        return this.execute(`/_nodes/${node.ec2Instance.privateIp}/stats`)
+            .then((nodeStats: NodeStats) => { return nodeStats.nodes[node.nodeId].indices.docs; });
+    }
+
+    setClusterSetting(settingName: string, settingValue: string): Promise<boolean> {
+        return this.executeCommand("/_cluster/settings", {
+            "transient": { [settingName]: settingValue }
+        }, `setting cluster setting ${settingName} to '${settingValue}'`)
+    }
+
+    updateRebalancingStatus(status: string): Promise<boolean> {
+        return this.setClusterSetting("cluster.routing.rebalance.enable", status);
+    }
+
+    excludeFromAllocation(ip: string): Promise<boolean> {
+        return this.setClusterSetting("cluster.routing.allocation.exclude._ip", ip);
+    }
 }
 
-export function getDocuments(node: ElasticsearchNode): Promise<Documents> {
-    return ssmCommand(`curl localhost:9200/_nodes/${node.ec2Instance.privateIp}/stats`, node.ec2Instance.id)
-        .then(response => {
-            const nodeStats: NodeStats = JSON.parse(response);
-            return nodeStats.nodes[node.nodeId].indices.docs;
-        });
-}
-
-export function updateRebalancingStatus(instanceId: string, status: string): Promise<boolean> {
-    const disableRebalancingCommand: object =
-        {
-            "transient": {
-                "cluster.routing.rebalance.enable": status
-            }
-        };
-    const elasticsearchCommand = `curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d '${JSON.stringify(disableRebalancingCommand)}'`;
-    return ssmCommand(elasticsearchCommand, instanceId)
-        .then((rawResponse: string) => {
-            if (!successfulAction(rawResponse)) {
-                throw `unexpected Elasticsearch response when attempting to update re-balancing status, we got: ${rawResponse}`;
-            } else {
-                console.log(`Successfully updated re-balancing status of cluster to: ${status}`);
-                return true;
-            }
-        })
-}
-
-export function excludeFromAllocation(ip: string, instanceId: string): Promise<boolean> {
-    const setting = {
-        "transient" : {
-            "cluster.routing.allocation.exclude._ip" : ip
-        }
-    };
-    const command = `curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d '${JSON.stringify(setting)}'`;
-
-    return ssmCommand(command, instanceId)
-        .then((rawResponse: string) => {
-            if (!successfulAction(rawResponse)) {
-                throw `Unexpected Elasticsearch response when attempting to exclude ${ip} from shard allocation, got: ${rawResponse}`;
-            } else {
-                console.log(`Successfully excluded ${ip} from shard allocation`);
-                return true;
-            }
-        });
-}
-
-function successfulAction(rawResponse: string): boolean {
-    const jsonResult = JSON.parse(rawResponse);
-    return jsonResult.acknowledged === true;
-}

--- a/src/getOldestNode.ts
+++ b/src/getOldestNode.ts
@@ -1,6 +1,6 @@
 import {AutoScalingGroupCheckResponse, OldestNodeResponse} from './utils/handlerInputs';
 import {getSpecificInstance} from './aws/ec2Instances';
-import {getElasticsearchNode} from './elasticsearch/elasticsearch';
+import {Elasticsearch} from './elasticsearch/elasticsearch';
 import {Instance} from './aws/types';
 
 export async function handler(event: AutoScalingGroupCheckResponse): Promise<OldestNodeResponse> {
@@ -9,7 +9,9 @@ export async function handler(event: AutoScalingGroupCheckResponse): Promise<Old
         const instances: string[] = event.instanceIds
         console.log(`Searching for oldest node in ${asg}`)
         const specificInstance = await getSpecificInstance(instances, findOldestInstance)
-        const node = await getElasticsearchNode(specificInstance)
+        const elasticsearchClient = new Elasticsearch(specificInstance.id)
+
+        const node = await elasticsearchClient.getElasticsearchNode(specificInstance)
 
         return ({
             asgName: event.asgName,

--- a/src/migrateShards.ts
+++ b/src/migrateShards.ts
@@ -1,16 +1,14 @@
 import {OldAndNewNodeResponse} from './utils/handlerInputs';
-import {
-    excludeFromAllocation,
-    updateRebalancingStatus
-} from './elasticsearch/elasticsearch';
+import {Elasticsearch} from './elasticsearch/elasticsearch';
 
 export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNodeResponse> {
 
     return new Promise<OldAndNewNodeResponse>((resolve, reject) => {
         const oldInstance = event.oldestElasticsearchNode.ec2Instance;
+        const elasticsearchClient = new Elasticsearch(oldInstance.id)
 
-        excludeFromAllocation(oldInstance.privateIp, oldInstance.id)
-            .then(() => updateRebalancingStatus(oldInstance.id, "all"))
+        elasticsearchClient.excludeFromAllocation(oldInstance.privateIp)
+            .then(() => elasticsearchClient.updateRebalancingStatus("all"))
             .then(() => resolve(event))
             .catch(error => {
                 console.log(`Failed to perform shard migration due to: ${error}`);

--- a/src/shardMigrationCheck.ts
+++ b/src/shardMigrationCheck.ts
@@ -1,10 +1,12 @@
 import {OldAndNewNodeResponse} from './utils/handlerInputs';
-import {getClusterHealth, getDocuments} from './elasticsearch/elasticsearch';
+import {Elasticsearch} from './elasticsearch/elasticsearch';
 
 export async function handler(event: OldAndNewNodeResponse): Promise<OldAndNewNodeResponse> {
+    const elasticsearchClient = new Elasticsearch(event.oldestElasticsearchNode.ec2Instance.id)
+
     return Promise.all([
-        getClusterHealth(event.oldestElasticsearchNode.ec2Instance.id),
-        getDocuments(event.oldestElasticsearchNode)
+        elasticsearchClient.getClusterHealth(),
+        elasticsearchClient.getDocuments(event.oldestElasticsearchNode)
     ]).then(([clusterStatus, documents]) => {
         const hasDocuments = documents.count > 0;
         const clusterIsUnhealthy = !(clusterStatus.status === "green");

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,6 +2326,11 @@ lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"


### PR DESCRIPTION
Node rotations have failed twice in the past week due to Elasticsearch requests to update cluster settings coming back with `acknowledged: false` (see #82). These updates are idempotent, so this PR uses ENR's already-existing [`retry()`](https://github.com/guardian/elasticsearch-node-rotation/blob/7f4cf63fc151fdbe47b399acb94908a0b931483c/src/utils/helperFunctions.ts#L7) function to retry the requests to Elasticsearch rather than failing immediately.

In addition to introducing retries, this also:

- Removes code repetition between the two cluster-settings commands (`excludeFromAllocation()` & `updateRebalancingStatus()`)
- Introduces an elasticsearch client class that means the target node instance id doesn't need to be passed around

### Trying this out...

We've [deployed](https://riffraff.gutools.co.uk/deployment/view/54765d00-97b0-4de1-b8a4-5bf748502a81) this to the Ophan AWS account as build [226](https://teamcity.gutools.co.uk/viewLog.html?buildId=704689&tab=buildResultsDiv&buildTypeId=Tools_ElasticsearchNodeRotation), and run a few test rotations ([first on a master node](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/arn:aws:states:eu-west-1:021353022223:execution:ophan-Elasticsearch-Node-Rotation-INFRA:roberto-test), and [then on a data node](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/arn:aws:states:eu-west-1:021353022223:execution:ophan-Elasticsearch-Node-Rotation-INFRA:roberto-test-2)) - both were successful:

![image](https://user-images.githubusercontent.com/52038/140088923-c3d26de5-3829-4629-b6f4-f248172db056.png)

![image](https://user-images.githubusercontent.com/52038/140087162-97df9dbc-9541-4b08-ace9-23c12ae5f814.png)

In the logging we see:

> Number of retries remaining 5 when setting cluster setting cluster.routing.rebalance.enable to 'none'

...and later, logged by the `retry()` function:

> Succeeded when setting cluster setting cluster.routing.rebalance.enable to 'none'