### PR TITLE
Increase total retry time from 5.5 to 6.5 hours

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -481,7 +481,7 @@ Resources:
                   "Retry": [ {
                     "ErrorEquals": [ "States.ALL" ],
                     "IntervalSeconds": 120,
-                    "MaxAttempts": 150,
+                    "MaxAttempts": 195,
                     "BackoffRate": 1.0
                   } ]
                 },


### PR DESCRIPTION
## What does this change?

This changes makes the step function wait for another hour for the cluster to finish migrating docs from the old node (following on from #76)

## How to test

This is a cloudformation change test so I think we can just release this and if the CFN is valid, we should be ok.

## How can we measure success?

We stop getting failures due to the migration taking too long
