### PR TITLE
Fix logging of Elasticsearch response after PR #83

### DIFF
--- a/src/elasticsearch/elasticsearch.ts
+++ b/src/elasticsearch/elasticsearch.ts
@@ -21,7 +21,7 @@ export class Elasticsearch {
     executeCommand(commandPath: string, requestJson: object, taskName: string): Promise<boolean> {
         return retry(() => this.execute(commandPath, requestJson).then((jsonResult: any) => {
             if (!(jsonResult.acknowledged === true)) {
-                throw `unexpected Elasticsearch response when attempting to ${taskName}, we got: ${jsonResult}`;
+                throw `unexpected Elasticsearch response when attempting to ${taskName}, we got: ${JSON.stringify(jsonResult)}`;
             } else {
                 return true;
             }


### PR DESCRIPTION
The updates in PR #83 made the logging of an unsuccessful Elasticsearch response unhelpful -`jsonResult` is a Javascript `Object`, which doesn't automatically become a helpful string! The [logs](https://logs.gutools.co.uk/s/ophan/goto/06499fa5f7753da98efbd064e1760119) just said `[object Object]` for the response...

> Failed when setting cluster setting cluster.routing.rebalance.enable to 'none' with : unexpected Elasticsearch response when attempting to setting cluster setting cluster.routing.rebalance.enable to 'none', we got: [object Object]

...when what we want is more like this, which this new PR should provide:

> Failed when setting cluster setting cluster.routing.rebalance.enable to 'none' with : unexpected Elasticsearch response when attempting to setting cluster setting cluster.routing.rebalance.enable to 'none', we got: {"acknowledged":false,"persistent":{},"transient":{"cluster":{"routing":{"rebalance":{"enable":"none"}}}}}
