### PR TITLE
correct note about `RotateWithElasticsearchNodeRotation` tag

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: "Step Function for rotating ElasticSearch nodes (regardless of their Stage, i.e. the INFRA/PROD instance of this stack will rotate oldest ES instances belonging to any Stage, assuming the instances have the `RotateWithElasticsearchNodeRotation` tag set to true)"
+Description: "Step Function for rotating ElasticSearch nodes (regardless of their Stage, i.e. the INFRA/PROD instance of this stack will rotate oldest ES instances belonging to any Stage, assuming the AutoScalingGroup has the `RotateWithElasticsearchNodeRotation` tag set to true)"
 
 Parameters:
   Stack:


### PR DESCRIPTION
Tiny correction to something I added a while ago - the `RotateWithElasticsearchNodeRotation` tag is only relevant on the ASG not the instances (in fact we're removing the propagation to instances in https://github.com/guardian/editorial-tools-platform/pull/577) 