### PR TITLE
Revert "correct note about `RotateWithElasticsearchNodeRotation` tag"

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: "Step Function for rotating ElasticSearch nodes (regardless of their Stage, i.e. the INFRA/PROD instance of this stack will rotate oldest ES instances belonging to any Stage, assuming the AutoScalingGroup has the `RotateWithElasticsearchNodeRotation` tag set to true)"
+Description: "Step Function for rotating ElasticSearch nodes (regardless of their Stage, i.e. the INFRA/PROD instance of this stack will rotate oldest ES instances belonging to any Stage, assuming the instances have the `RotateWithElasticsearchNodeRotation` tag set to true)"
 
 Parameters:
   Stack:


### PR DESCRIPTION
Reverts guardian/elasticsearch-node-rotation#89

Turns out I was incorrect - the `RotateWithElasticsearchNodeRotation` tag IS required on at least one instance per STAGE, to find the appropriate ASG in the first place - this is silly, in a separate PR I will make it such that it actually uses the tag on the instance for filtering purposes when on the the `GetOldestNode` step, since that's what was confusing.