### PR TITLE
Add deployment of elasticsearch node rotation to capi AWS account

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -71,7 +71,7 @@ deployments:
   content-api-enr-cloudformation:
     stacks: [ content-api]
     template: cloudformation
-    app: content-api-es-node-rotation
+    app: elasticsearch-node-rotation
   content-api-enr-lambda:
     stacks: [ content-api ]
     dependencies: [ content-api-enr-cloudformation ]

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -68,6 +68,16 @@ deployments:
     parameters:
       bucket: infosec-dist
 
+  content-api-enr-cloudformation:
+    stacks: [ content-api]
+    template: cloudformation
+    app: content-api-es-node-rotation
+  content-api-enr-lambda:
+    stacks: [ content-api ]
+    dependencies: [ content-api-enr-cloudformation ]
+    template: lambda
+    parameters:
+      bucket: content-api-dist
 
   # Giant (pfi) uses elasticsearch-node-rotation but we don't allow continuous deployment
   # of it into the account to minimise the deployment points for code that has access


### PR DESCRIPTION
## What does this change?
 
This adds the details needed to deploy elasticsearch node rotation to capi AWS in the riffraff.yaml file.
## How to test

TBC

## How can we measure success?

TBC

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
