### PR TITLE
fix: Remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "riffraffFile": "riff-raff.yaml",
   "dependencies": {
     "aws-sdk": "^2.1052.0",
-    "lodash": "^4.17.21",
     "node-riffraff-artefact": "^2.0.1",
     "typescript": "4.6.4"
   },

--- a/src/getTargetNode.ts
+++ b/src/getTargetNode.ts
@@ -1,4 +1,3 @@
-import * as sortBy from 'lodash/sortBy';
 import {AsgDiscoveryResponse, StateMachineInput} from './utils/handlerInputs';
 import {totalRunningExecutions} from "./aws/stepFunctions";
 import {getInstancesByTag} from './aws/ec2Instances';
@@ -66,4 +65,16 @@ export async function handler(event: StateMachineInput): Promise<AsgDiscoveryRes
     }
 }
 
-export const findOldestInstance = (instances: Instance[]) => sortBy(instances, instance => instance.launchTime)[0]
+export const findOldestInstance = (instances: Instance[]): Instance => {
+    const [head] = instances.sort(({ launchTime: launchTimeA }: Instance, { launchTime: launchTimeB }: Instance) => {
+        if(launchTimeA < launchTimeB) {
+            return -1;
+        }
+        if(launchTimeA > launchTimeB) {
+            return 1;
+        }
+        return 0;
+    });
+
+    return head;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,11 +1736,6 @@ lodash.memoize@4.x:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We're only using lodash to sort an array; we can do that fairly easily!

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

[Existing tests](https://github.com/guardian/elasticsearch-node-rotation/blob/8e3a72335335b6b17bc3220dabf86b2bd1396d72/test/getOldestInstance.test.ts) should continue to pass.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Fewer dependencies.