### PR TITLE
chore: Move typescript to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
   "riffraffFile": "riff-raff.yaml",
   "dependencies": {
     "aws-sdk": "^2.1052.0",
-    "node-riffraff-artefact": "^2.0.1",
-    "typescript": "4.6.4"
+    "node-riffraff-artefact": "^2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",
     "@types/node": "12.12.7",
     "jest": "^28.1.0",
-    "ts-jest": "^28.0.3"
+    "ts-jest": "^28.0.3",
+    "typescript": "4.6.4"
   },
   "scripts": {
     "clean": "rm -rf target",


### PR DESCRIPTION
Builds on #104.

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Moves Typescript to a dev dependency because it is one.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

CI should pass.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

This, in addition to #106 means only `aws-sdk` is in dependencies. This means we don't need to add `node_modules` to the lambda artifact as `aws-sdk` is included in the lambda runtime already. 