### PR TITLE
chore(deps): Bump aws-sdk to 2.1142.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elasticsearch-node-rotation",
   "dependencies": {
-    "aws-sdk": "^2.1052.0"
+    "aws-sdk": "^2.1142.0"
   },
   "devDependencies": {
     "@guardian/node-riffraff-artifact": "^0.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,7 +762,7 @@ async@^2.6.3:
   dependencies:
     lodash "^4.17.14"
 
-aws-sdk@^2.1052.0, aws-sdk@^2.946.0:
+aws-sdk@^2.1142.0, aws-sdk@^2.946.0:
   version "2.1142.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1142.0.tgz#8fca9cfa100153d10d753afbc11a3ad7af6fe72b"
   integrity sha512-ii+4Q8jqN31CiXpn9i/4vGCjqo02TGihmre5b44OUsTiKNXSjqr/aRrcirMsfuBFWRdrdcU12ez7Mg+N9GDNjw==


### PR DESCRIPTION
Builds on #106.

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

See https://security.snyk.io/vuln/SNYK-JS-AWSSDK-1059424, although it looks like we're already on a high enough version.