### PR TITLE
Add allowed stages to prevent accidents

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,5 +1,7 @@
 regions: [eu-west-1]
 
+allowedStages: [INFRA]
+
 templates:
   cloudformation:
     type: cloud-formation


### PR DESCRIPTION
[We only deploy this project to the `INFRA` stage.](https://riffraff.gutools.co.uk/deployment/history?projectName=elasticsearch-node-rotation&page=1)