### PR TITLE
Make `app` consistent across all stacks Riff-Raff deploys to (part 1)

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -29,7 +29,11 @@ deployments:
   deploy-tools-enr-cloudformation:
     stacks: [deploy]
     template: cloudformation
-    app: elk-data-node-rotation
+    parameters:
+      cloudFormationStackName: elasticsearch-node-rotation-INFRA
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      appendStageToCloudFormationStackName: false
   deploy-tools-enr-lambda:
     stacks: [deploy]
     dependencies: [deploy-tools-enr-cloudformation]
@@ -40,7 +44,11 @@ deployments:
   ophan-enr-cloudformation:
     stacks: [ophan]
     template: cloudformation
-    app: ophan-es-node-rotation
+    parameters:
+      cloudFormationStackName: ophan-elasticsearch-node-rotation-INFRA
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      appendStageToCloudFormationStackName: false
   ophan-enr-lambda:
     stacks: [ophan]
     dependencies: [ophan-enr-cloudformation]
@@ -51,7 +59,11 @@ deployments:
   grid-enr-cloudformation:
     stacks: [media-service]
     template: cloudformation
-    app: grid-es-node-rotation
+    parameters:
+      cloudFormationStackName: elasticsearch-node-rotation-INFRA
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      appendStageToCloudFormationStackName: false
   grid-enr-lambda:
     stacks: [media-service]
     dependencies: [grid-enr-cloudformation]
@@ -62,7 +74,11 @@ deployments:
   infosec-enr-cloudformation:
     stacks: [infosec]
     template: cloudformation
-    app: infosec-wazuh-es-rotation
+    parameters:
+      cloudFormationStackName: elasticsearch-node-rotation-INFRA
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      appendStageToCloudFormationStackName: false
   infosec-enr-lambda:
     stacks: [infosec]
     dependencies: [infosec-enr-cloudformation]
@@ -73,7 +89,11 @@ deployments:
   content-api-enr-cloudformation:
     stacks: [ content-api]
     template: cloudformation
-    app: elasticsearch-node-rotation
+    parameters:
+      cloudFormationStackName: content-api-elasticsearch-node-rotation-INFRA
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      appendStageToCloudFormationStackName: false
   content-api-enr-lambda:
     stacks: [ content-api ]
     dependencies: [ content-api-enr-cloudformation ]


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The variation of `app` is a little confusing and doesn't appear to be needed.

In this change, we explicitly instruct Riff-Raff to discover the CFN stack to affect by providing the `cloudFormationStackName` parameter. Removal of the `app` property should have the effect of:
  - RiffRaff finds a CFN stack via `cloudFormationStackName`
  - RiffRaff updates the `App` tag on the stack to match that of the [`template`](https://github.com/guardian/elasticsearch-node-rotation/blob/d6e07a4e511e16b12102c3e959b1430372382662/riff-raff.yaml#L8), i.e. making it consistent across instances of this stack
  - We can then, in #119, move to discovering the CFN stack via tag lookup

Setting `cloudFormationStackName` is necessary because if we were to just change `app` Riff-Raff would want to create a new CFN stack, which is not desired.

Using a single, consistent, value makes migration to GuCDK easier.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

We should still be able to deploy this service with Riff-Raff.