### PR TITLE
Parameterise cluster check attempts

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -34,7 +34,10 @@ Parameters:
   SNSTopicForAlerts:
     Type: String
     Description: The name of the SNS topic used for alerting in the case of a failed rotation attempt.
-
+  ClusterSizeCheckAttempts:
+    Type: Number
+    Description: The number of attempts to make when running the cluster size check before timing out.
+    Default: 20
 
 Conditions:
   ShouldCreateSsmOutputBucket: !Equals
@@ -445,7 +448,7 @@ Resources:
                   "Retry": [ {
                     "ErrorEquals": [ "States.ALL" ],
                     "IntervalSeconds": 30,
-                    "MaxAttempts": 20,
+                    "MaxAttempts": ${ClusterSizeCheckAttempts},
                     "BackoffRate": 1.0
                     } ]
                 },


### PR DESCRIPTION
## What does this change?

Adds a stack parameter to let users adjust how long the step function waits for a new instance to be available before giving up.

On Content Pipeline, we've had a few rotation failures in the CAPI cluster recently: provisioning an instance (m7g.2xlarge) has taken ~20mins due to there not being availability in the AZ.

While we have the appropriate conversations to figure out how we might avoid this, it seems sensible to bump wait time rather than manually rectify the cluster every time a rotation fails.

## How to test

Deploy and check the relevant step function configuration. Does the parameter take affect as expected?

## How can we measure success?

Fewer failures when CAPI rotates nodes.

## Have we considered potential risks?

This feels low risk, as we spin up a new node before culling the old one – the impact seems to be just on the overall length of the rotation function.