### PR TITLE
correct local variable name w.r.t. node being 'master-eligible' rather than 'master'

### DIFF
--- a/src/elasticsearch/elasticsearch.ts
+++ b/src/elasticsearch/elasticsearch.ts
@@ -37,8 +37,8 @@ export class Elasticsearch {
         return this.execute(`/_nodes/${instance.privateIp}`).then((json: any) => {
             if (json._nodes.total === 1) {
                 const nodeId: string = Object.keys(json.nodes)[0];
-                const isMaster: boolean = json.nodes[nodeId].settings.node.master == 'true';
-                return new ElasticsearchNode(instance, nodeId, isMaster);
+                const isMasterEligible: boolean = json.nodes[nodeId].settings.node.master == 'true';
+                return new ElasticsearchNode(instance, nodeId, isMasterEligible);
             } else {
                 throw `expected information about a single node, but got: ${JSON.stringify(json)}`;
             }


### PR DESCRIPTION
After investigating an ephemeral issue and trying to understand why a particular SSM command failed, we were confused by a discrepancy in a local variable name `isMaster` being passed to something expecting `isMasterEligible` (which subsequent logic relied on it meaning the latter AFAWCT).