### PR TITLE
Remove the infosec stack deployments from riff-raff.yaml

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -59,17 +59,6 @@ deployments:
     parameters:
       bucket: media-service-dist
 
-  infosec-enr-cloudformation:
-    stacks: [infosec]
-    template: cloudformation
-    app: infosec-wazuh-es-rotation
-  infosec-enr-lambda:
-    stacks: [infosec]
-    dependencies: [infosec-enr-cloudformation]
-    template: lambda
-    parameters:
-      bucket: infosec-dist
-
   content-api-enr-cloudformation:
     stacks: [ content-api]
     template: cloudformation


### PR DESCRIPTION
## What does this change?

InfoSec no longer needs to run an elasticsearch cluster. This change removes the deployments against this stack.