### PR TITLE
improve master-eligible node detection in node-rotation

### DIFF
--- a/src/elasticsearch/elasticsearch.ts
+++ b/src/elasticsearch/elasticsearch.ts
@@ -37,7 +37,7 @@ export class Elasticsearch {
         return this.execute(`/_nodes/${instance.privateIp}`).then((json: any) => {
             if (json._nodes.total === 1) {
                 const nodeId: string = Object.keys(json.nodes)[0];
-                const isMasterEligible: boolean = json.nodes[nodeId].settings.node.master == 'true';
+                const isMasterEligible: boolean = json.nodes[nodeId].settings.node.master == 'true' || json.nodes[nodeId].settings.node.roles.includes('master');
                 return new ElasticsearchNode(instance, nodeId, isMasterEligible);
             } else {
                 throw `expected information about a single node, but got: ${JSON.stringify(json)}`;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Modern ES configs have slightly changed where the master-eligibility setting is located, update the node rotation lambdas to take that into account.

(On a side note, we only check a node's master eligibility to [choose whether to attempt a graceful shutdown](https://github.com/guardian/elasticsearch-node-rotation/blob/a834a66c23dd10c6ad5fe96a6c741c7823ab672f/src/removeNode.ts#L13). Is there a reason that we wouldn't want to attempt graceful shutdowns on non-master nodes? An alternative to this PR would be to remove this detection of master-eligibility and always attempt the graceful shutdown.) 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
