### PR TITLE
Fix dangling promise in ClusterSizeCheck handler

### DIFF
--- a/src/clusterSizeCheck.ts
+++ b/src/clusterSizeCheck.ts
@@ -11,13 +11,13 @@ export async function handler(event: AddNodeResponse): Promise<TargetAndNewNodeR
     const instanceIds = asg.Instances.map(i  => i.InstanceId)
     const newestInstance = await getSpecificInstance(instanceIds, findNewestInstance)
     const elasticsearchClient = new Elasticsearch(event.targetElasticSearchNode.ec2Instance.id)
-    const newestNode = elasticsearchClient.getElasticsearchNode(newestInstance)
 
     return new Promise<TargetAndNewNodeResponse>((resolve, reject) => {
         elasticsearchClient.getClusterHealth()
             .then((clusterStatus: ElasticsearchClusterStatus) => {
                 const nodesInCluster = clusterStatus.number_of_nodes;
                 if (nodesInCluster === event.expectedClusterSize) {
+                    const newestNode = elasticsearchClient.getElasticsearchNode(newestInstance);
                     return newestNode;
                 } else {
                     const error = `Found ${nodesInCluster} nodes but expected to find ${event.expectedClusterSize}`;


### PR DESCRIPTION
## What does this change?

We are sometimes seeing the following error in prod
```
{
  "error": "Runtime.UnhandledPromiseRejection",
  "cause": {
    "errorType": "Runtime.UnhandledPromiseRejection",
    "errorMessage": "expected information about a single node, but got: {\"_nodes\":{\"total\":0,\"successful\":0,\"failed\":0},\"cluster_name\":\"elk\",\"nodes\":{}}",
    "trace": [
      "Runtime.UnhandledPromiseRejection: expected information about a single node, but got: {\"_nodes\":{\"total\":0,\"successful\":0,\"failed\":0},\"cluster_name\":\"elk\",\"nodes\":{}}",
      "    at process.<anonymous> (file:///var/runtime/index.mjs:1448:17)",
      "    at process.emit (node:events:524:28)",
      "    at emitUnhandledRejection (node:internal/process/promises:250:13)",
      "    at throwUnhandledRejectionsMode (node:internal/process/promises:385:19)",
      "    at processPromiseRejections (node:internal/process/promises:470:17)",
      "    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)"
    ]
  }
}
```

This patch attempts to fix this.

The general idea is that the code for `clusterSizeCheck` calls `getElasticsearchNode` immediately up top
```ts
const newestNode = elasticsearchClient.getElasticsearchNode(newestInstance)
```

Even though it only needs it later, inside a promise chain IF the number of nodes in the cluster matches expectation.
```
                if (nodesInCluster === event.expectedClusterSize) {
                    return newestNode;
                }
```

The issue arises because `getElasticsearchNode` [can throw](https://github.com/guardian/elasticsearch-node-rotation/blob/c81dbd799aba39ab0ce1df17f6ef48f5d9be2428/src/elasticsearch/elasticsearch.ts#L45), but it's not wrapped in any code that can deal with it, so the promise rejection is unhandled. The promise is effectively "dangling".

This patch moves the `getElasticsearchNode`  to inside the promise chain, inside the if clause, which means it only runs when it needs to, and if it throws an error it will be caught.

## How has this change been tested?

I've been able to force `clusterSizeCheck` to run locally using the same lambda input event it processed in PROD. It threw the same error in the console
```
Newest instance i-0c2c7618279c02ef4 was launched at Thu Apr 16 2026 10:01:54 GMT+0100 (British Summer Time)
Searching for Elasticsearch node with private ip: 10.248.1.1
sending SSM command: curl localhost:9200/_nodes/10.248.1.1  for instance: i-abcdefghi
sending SSM command: curl localhost:9200/_cluster/health  for instance: i-abcdefghi
Final state: Success; remaining retries: 6
Final state: Success; remaining retries: 6
node:internal/process/promises:389
      new UnhandledPromiseRejection(reason);
      ^

UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "expected information about a single node, but got: {"_nodes":{"total":0,"successful":0,"failed":0},"cluster_name":"elk","nodes":{}}".
    at throwUnhandledRejectionsMode (node:internal/process/promises:389:7)
    at processPromiseRejections (node:internal/process/promises:470:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:96:32) {
  code: 'ERR_UNHANDLED_REJECTION'
}
```

After the patch, we can see that `getElasticsearchNode` is no longer called (no `Searching for Elasticsearch node with private ip:` messages), so there's no longer an error
```
Newest instance i-abcdefghi was launched at Thu Apr 16 2026 10:01:54 GMT+0100 (British Summer Time)
sending SSM command: curl localhost:9200/_cluster/health  for instance:  i-abcdefghi
Final state: Success; remaining retries: 6
Found 16 nodes but expected to find 17
Failed: Found 16 nodes but expected to find 17
```

## Have we considered potential risks?

The risk here is breaking node rotation for our clients. To mitigate this, we should run a node rotation in deploy tools straight away after deployment.